### PR TITLE
Enable the driver to determine IMU sample rate from the IMU type

### DIFF
--- a/novatel_gps_driver/include/novatel_gps_driver/novatel_gps.h
+++ b/novatel_gps_driver/include/novatel_gps_driver/novatel_gps.h
@@ -242,8 +242,9 @@ namespace novatel_gps_driver
       /**
        * @brief Sets the IMU rate; necessary for producing sensor_msgs/Imu messages.
        * @param imu_rate The IMU rate in Hz.
+       * @param force If this value should be used instead of an autodetected one
        */
-      void SetImuRate(double imu_rate);
+      void SetImuRate(double imu_rate, bool force = true);
 
       //parameters
       double gpgga_gprmc_sync_tol_; //seconds
@@ -369,6 +370,7 @@ namespace novatel_gps_driver
       std::string error_msg_;
 
       bool is_connected_;
+      bool imu_rate_forced_;
 
       double utc_offset_;
 

--- a/novatel_gps_driver/src/nodelets/novatel_gps_nodelet.cpp
+++ b/novatel_gps_driver/src/nodelets/novatel_gps_nodelet.cpp
@@ -161,7 +161,7 @@ namespace novatel_gps_driver
       publish_gpgsa_(false),
       publish_gpgsv_(false),
       imu_rate_(100.0),
-      imu_sample_rate_(200.0),
+      imu_sample_rate_(-1),
       publish_imu_messages_(false),
       publish_novatel_positions_(false),
       publish_novatel_velocity_(false),
@@ -369,7 +369,12 @@ namespace novatel_gps_driver
           NODELET_WARN("Using the ASCII message format with CORRIMUDATA logs is not recommended.  "
                        "A serial link will not be able to keep up with the data rate.");
         }
-        gps_.SetImuRate(imu_sample_rate_);
+
+        // Only configure the imu rate if we set the param
+        if (imu_sample_rate_ > 0)
+        {
+          gps_.SetImuRate(imu_sample_rate_, true);
+        }
       }
       if (publish_novatel_velocity_)
       {

--- a/novatel_gps_driver/src/novatel_gps.cpp
+++ b/novatel_gps_driver/src/novatel_gps.cpp
@@ -1244,7 +1244,7 @@ namespace novatel_gps_driver
        };
       
       // Parse out the IMU type then save it, we don't care about the rest (3rd field)
-      std::string id = sentence.body.size() > 2 ? sentence.body[2] : "";
+      std::string id = sentence.body.size() > 1 ? sentence.body[1] : "";
       if (rates.find(id) != rates.end())
       {
         double rate = rates[id].first;

--- a/novatel_gps_driver/src/novatel_gps.cpp
+++ b/novatel_gps_driver/src/novatel_gps.cpp
@@ -68,7 +68,8 @@ namespace novatel_gps_driver
       range_msgs_(MAX_BUFFER_SIZE),
       time_msgs_(MAX_BUFFER_SIZE),
       trackstat_msgs_(MAX_BUFFER_SIZE),
-      imu_rate_(-1.0)
+      imu_rate_(-1.0),
+      imu_rate_forced_(false)
   {
   }
 
@@ -963,10 +964,14 @@ namespace novatel_gps_driver
     ROS_DEBUG("Created %lu new sensor_msgs/Imu messages.", new_size);
   }
 
-  void NovatelGps::SetImuRate(double imu_rate)
+  void NovatelGps::SetImuRate(double imu_rate, bool imu_rate_forced)
   {
     ROS_INFO("IMU sample rate: %f", imu_rate);
     imu_rate_ = imu_rate;
+    if (imu_rate_forced)
+    {
+      imu_rate_forced_ = true;
+    }
   }
 
   NovatelGps::ReadResult NovatelGps::ParseBinaryMessage(const BinaryMessage& msg,
@@ -1210,6 +1215,54 @@ namespace novatel_gps_driver
       trackstat->header.stamp = stamp;
       trackstat_msgs_.push_back(trackstat);
     }
+    else if (sentence.id == "RAWIMUX")
+    {
+      static std::map<std::string, double> rates = {
+        { "0",  100 }, // Unknown
+        { "1",  100 }, // Honeywell HG1700 AG11
+        { "4",  100 }, // Honeywell HG1700 AG17
+        { "5",  100 }, // Honeywell HG1700 CA29
+        { "8",  200 }, // Litton LN-200 (200hz model)
+        { "11", 100 }, // Honeywell HG1700 AG58
+        { "12", 100 }, // Honeywell HG1700 AG62
+        { "13", 200 }, // iMAR ilMU-FSAS
+        { "16", 200 }, // KVH 1750 IMU
+        { "19", 200 }, // Northrop Grumman Litef LCI-1
+        { "20", 100 }, // Honeywell HG1930 AA99
+        { "26", 100 }, // Northrop Grumman Litef ISA-100C
+        { "27", 100 }, // Honeywell HG1900 CA50
+        { "28", 100 }, // Honeywell HG1930 CA50
+        { "31", 200 }, // Analog Devices ADIS16488
+        { "32", 125 }, // Sensonor STIM300
+        { "33", 200 }, // KVH1750 IMU
+        { "34", 200 }, // Northrop Grumman Litef ISA-100
+        { "38", 400 }, // Northrop Grumman Litef ISA-100 400Hz
+        { "39", 400 }, // Northrop Grumman Litef ISA-100C 400Hz
+        { "45", 100 }, // KVH 1725 IMU (This was a guess based on the 1750
+                       // as the actual rate is not documented and the specs are similar)
+        { "52", 200 }, // Litef microIMU
+       };
+      
+      // Parse out the IMU type then save it, we don't care about the rest (3rd field)
+      std::string id = sentence.body.size() > 2 ? sentence.body[2] : "";
+      if (rates.find(id) != rates.end())
+      {
+        double rate = rates[id];
+ 
+        ROS_INFO("IMU Type %s Found, Rate: %f Hz", id.c_str(), (float)rate);
+        
+        // Set the rate only if it hasnt been forced already
+        if (imu_rate_forced_ == false)
+        {        
+          SetImuRate(rate, false); // Dont force set from here so it can be configured elsewhere
+        }
+      }
+      else
+      {
+        // Error because the imu type was unknown
+        ROS_ERROR("Unknown IMU Type Received: %s", id.c_str());
+      }
+    }
 
     return READ_SUCCESS;
   }
@@ -1275,6 +1328,10 @@ namespace novatel_gps_driver
       command << "log " << option->first << " ontime " << option->second << "\n";
       configured = configured && Write(command.str());
     }
+
+    // Log the IMU data once to get the IMU type
+    configured = configured && Write("log rawimux\n");
+
     return configured;
   }
 }

--- a/novatel_gps_driver/src/novatel_gps.cpp
+++ b/novatel_gps_driver/src/novatel_gps.cpp
@@ -1215,41 +1215,41 @@ namespace novatel_gps_driver
       trackstat->header.stamp = stamp;
       trackstat_msgs_.push_back(trackstat);
     }
-    else if (sentence.id == "RAWIMUX")
+    else if (sentence.id == "RAWIMUXA")
     {
-      static std::map<std::string, double> rates = {
-        { "0",  100 }, // Unknown
-        { "1",  100 }, // Honeywell HG1700 AG11
-        { "4",  100 }, // Honeywell HG1700 AG17
-        { "5",  100 }, // Honeywell HG1700 CA29
-        { "8",  200 }, // Litton LN-200 (200hz model)
-        { "11", 100 }, // Honeywell HG1700 AG58
-        { "12", 100 }, // Honeywell HG1700 AG62
-        { "13", 200 }, // iMAR ilMU-FSAS
-        { "16", 200 }, // KVH 1750 IMU
-        { "19", 200 }, // Northrop Grumman Litef LCI-1
-        { "20", 100 }, // Honeywell HG1930 AA99
-        { "26", 100 }, // Northrop Grumman Litef ISA-100C
-        { "27", 100 }, // Honeywell HG1900 CA50
-        { "28", 100 }, // Honeywell HG1930 CA50
-        { "31", 200 }, // Analog Devices ADIS16488
-        { "32", 125 }, // Sensonor STIM300
-        { "33", 200 }, // KVH1750 IMU
-        { "34", 200 }, // Northrop Grumman Litef ISA-100
-        { "38", 400 }, // Northrop Grumman Litef ISA-100 400Hz
-        { "39", 400 }, // Northrop Grumman Litef ISA-100C 400Hz
-        { "45", 200 }, // KVH 1725 IMU (This was a guess based on the 1750
+      static std::map<std::string, std::pair<double, std::string>> rates = {
+        { "0",  std::pair<double, std::string>(100, "Unknown") },
+        { "1",  std::pair<double, std::string>(100, "Honeywell HG1700 AG11") },
+        { "4",  std::pair<double, std::string>(100, "Honeywell HG1700 AG17") },
+        { "5",  std::pair<double, std::string>(100, "Honeywell HG1700 CA29") },
+        { "8",  std::pair<double, std::string>(200, "Litton LN-200 (200hz model)") },
+        { "11", std::pair<double, std::string>(100, "Honeywell HG1700 AG58") },
+        { "12", std::pair<double, std::string>(100, "Honeywell HG1700 AG62") },
+        { "13", std::pair<double, std::string>(200, "iMAR ilMU-FSAS") },
+        { "16", std::pair<double, std::string>(200, "KVH 1750 IMU") },
+        { "19", std::pair<double, std::string>(200, "Northrop Grumman Litef LCI-1") },
+        { "20", std::pair<double, std::string>(100, "Honeywell HG1930 AA99") },
+        { "26", std::pair<double, std::string>(100, "Northrop Grumman Litef ISA-100C") },
+        { "27", std::pair<double, std::string>(100, "Honeywell HG1900 CA50") },
+        { "28", std::pair<double, std::string>(100, "Honeywell HG1930 CA50") },
+        { "31", std::pair<double, std::string>(200, "Analog Devices ADIS16488") },
+        { "32", std::pair<double, std::string>(125, "Sensonor STIM300") },
+        { "33", std::pair<double, std::string>(200, "KVH1750 IMU") },
+        { "34", std::pair<double, std::string>(200, "Northrop Grumman Litef ISA-100") },
+        { "38", std::pair<double, std::string>(400, "Northrop Grumman Litef ISA-100 400Hz") },
+        { "39", std::pair<double, std::string>(400, "Northrop Grumman Litef ISA-100C 400Hz") },
+        { "45", std::pair<double, std::string>(200, "KVH 1725 IMU?") }, //(This was a guess based on the 1750
                        // as the actual rate is not documented and the specs are similar)
-        { "52", 200 }, // Litef microIMU
+        { "52", std::pair<double, std::string>(200, "Litef microIMU") },
        };
       
       // Parse out the IMU type then save it, we don't care about the rest (3rd field)
       std::string id = sentence.body.size() > 2 ? sentence.body[2] : "";
       if (rates.find(id) != rates.end())
       {
-        double rate = rates[id];
+        double rate = rates[id].first;
  
-        ROS_INFO("IMU Type %s Found, Rate: %f Hz", id.c_str(), (float)rate);
+        ROS_INFO("IMU Type %s Found, Rate: %f Hz", rates[id].second.c_str(), (float)rate);
         
         // Set the rate only if it hasnt been forced already
         if (imu_rate_forced_ == false)
@@ -1330,7 +1330,7 @@ namespace novatel_gps_driver
     }
 
     // Log the IMU data once to get the IMU type
-    configured = configured && Write("log rawimux\n");
+    configured = configured && Write("log rawimuxa\n");
 
     return configured;
   }

--- a/novatel_gps_driver/src/novatel_gps.cpp
+++ b/novatel_gps_driver/src/novatel_gps.cpp
@@ -1238,7 +1238,7 @@ namespace novatel_gps_driver
         { "34", 200 }, // Northrop Grumman Litef ISA-100
         { "38", 400 }, // Northrop Grumman Litef ISA-100 400Hz
         { "39", 400 }, // Northrop Grumman Litef ISA-100C 400Hz
-        { "45", 100 }, // KVH 1725 IMU (This was a guess based on the 1750
+        { "45", 200 }, // KVH 1725 IMU (This was a guess based on the 1750
                        // as the actual rate is not documented and the specs are similar)
         { "52", 200 }, // Litef microIMU
        };


### PR DESCRIPTION
This enables the user to not have to have to manually set the IMU Internal Sample Rate to get correct IMU data from NovaTel SPAN. Also change from defaulting to a 200 Hz IMU sample rate to using autodetection.

Implements #8