### PR TITLE
Add FRESET service to novatel_gps_nodelet

### DIFF
--- a/novatel_gps_driver/include/novatel_gps_driver/novatel_gps.h
+++ b/novatel_gps_driver/include/novatel_gps_driver/novatel_gps.h
@@ -245,6 +245,13 @@ namespace novatel_gps_driver
        */
       void SetImuRate(double imu_rate);
 
+      /**
+       * @brief Writes the given string of characters to a connected NovAtel device.
+       * @param command A string to transmit.
+       * @return true if we successfully wrote all of the data, false otherwise.
+       */
+      bool Write(const std::string& command);
+
       //parameters
       double gpgga_gprmc_sync_tol_; //seconds
       double gpgga_position_sync_tol_; //seconds
@@ -348,13 +355,6 @@ namespace novatel_gps_driver
        * @return The status of the read operation.
        */
       ReadResult ReadData();
-
-      /**
-       * @brief Writes the given string of characters to a connected NovAtel device.
-       * @param command A string to transmit.
-       * @return true if we successfully wrote all of the data, false otherwise.
-       */
-      bool Write(const std::string& command);
 
       static constexpr uint16_t DEFAULT_TCP_PORT = 3001;
       static constexpr uint16_t DEFAULT_UDP_PORT = 3002;

--- a/novatel_gps_driver/src/nodelets/novatel_gps_nodelet.cpp
+++ b/novatel_gps_driver/src/nodelets/novatel_gps_nodelet.cpp
@@ -64,6 +64,12 @@
  * \e trackstat <tt>novatel_gps_msgs/Trackstat</tt> - Novatel-specific trackstat
  *    data at 1 Hz. (Only published if `publish_trackstat` is set `true`.)
  *
+ * <b>Services:</b>
+ *
+ * \e freset <tt>novatel_gps_msgs/NovatelFRESET</tt> - Sends a freset message to the
+ *    device with the specified target string to reset. By default does
+ *    FRESET standard
+ *
  * <b>Parameters:</b>
  *
  * \e connection_type <tt>str</tt> - "serial", "udp", or "tcp" as appropriate
@@ -235,7 +241,7 @@ namespace novatel_gps_driver
       swri::param(priv, "wait_for_position", gps_.wait_for_position_, false);
 
       // Reset Service
-      reset_service_ = node.advertiseService("freset", &NovatelGpsNodelet::resetService, this);
+      reset_service_ = priv.advertiseService("freset", &NovatelGpsNodelet::resetService, this);
 
       sync_sub_ = swri::Subscriber(node, "gps_sync", 100, &NovatelGpsNodelet::SyncCallback, this);
 
@@ -553,6 +559,11 @@ namespace novatel_gps_driver
       command += req.target.length() ? "STANDARD" : req.target;
       command += '\n';
       gps_.Write(command);
+
+      if (req.target.length() == 0)
+      {
+        ROS_WARN("No FRESET target specified. Doing FRESET STANDARD. This may be undesired behavior.");
+      }
 
       res.success = true;
       return true;

--- a/novatel_gps_driver/src/nodelets/novatel_gps_nodelet.cpp
+++ b/novatel_gps_driver/src/nodelets/novatel_gps_nodelet.cpp
@@ -130,6 +130,7 @@
 #include <gps_common/GPSFix.h>
 #include <nodelet/nodelet.h>
 #include <novatel_gps_msgs/NovatelCorrectedImuData.h>
+#include <novatel_gps_msgs/NovatelFRESET.h>
 #include <novatel_gps_msgs/NovatelMessageHeader.h>
 #include <novatel_gps_msgs/NovatelPosition.h>
 #include <novatel_gps_msgs/NovatelVelocity.h>
@@ -232,6 +233,9 @@ namespace novatel_gps_driver
       swri::param(priv, "gpgga_gprmc_sync_tol", gps_.gpgga_gprmc_sync_tol_, 0.01);
       swri::param(priv, "gpgga_position_sync_tol", gps_.gpgga_position_sync_tol_, 0.01);
       swri::param(priv, "wait_for_position", gps_.wait_for_position_, false);
+
+      // Reset Service
+      reset_service_ = node.advertiseService("freset", &NovatelGpsNodelet::resetService, this);
 
       sync_sub_ = swri::Subscriber(node, "gps_sync", 100, &NovatelGpsNodelet::SyncCallback, this);
 
@@ -491,6 +495,8 @@ namespace novatel_gps_driver
     ros::Publisher time_pub_;
     ros::Publisher trackstat_pub_;
 
+    ros::ServiceServer reset_service_;
+
     NovatelGps::ConnectionType connection_;
     NovatelGps gps_;
 
@@ -530,6 +536,27 @@ namespace novatel_gps_driver
 
     std::string imu_frame_id_;
     std::string frame_id_;
+
+    /**
+     * @brief Service request to reset the gps through FRESET
+     */
+    bool resetService(novatel_gps_msgs::NovatelFRESET::Request& req,
+                      novatel_gps_msgs::NovatelFRESET::Response& res)
+    {
+      if (gps_.IsConnected() == false)
+      {
+        res.success = false;
+      }
+      
+      // Formulate the reset command and send it to the device
+      std::string command = "FRESET ";
+      command += req.target.length() ? "STANDARD" : req.target;
+      command += '\n';
+      gps_.Write(command);
+
+      res.success = true;
+      return true;
+    }
 
     /**
      * @brief Reads data from the device and publishes any parsed messages.

--- a/novatel_gps_msgs/CMakeLists.txt
+++ b/novatel_gps_msgs/CMakeLists.txt
@@ -9,6 +9,11 @@ find_package(catkin REQUIRED COMPONENTS
   ${MSG_DEPS}
 )
 
+add_service_files(
+  FILES
+  NovatelFRESET.srv
+)
+
 add_message_files(DIRECTORY msg FILES
   Gpgga.msg
   Gpgsa.msg

--- a/novatel_gps_msgs/srv/NovatelFRESET.srv
+++ b/novatel_gps_msgs/srv/NovatelFRESET.srv
@@ -1,0 +1,10 @@
+# Request to send a FRESET command to the Novatel unit
+#Request
+
+string target
+
+---
+
+#Response
+bool success
+


### PR DESCRIPTION
Add service to novatel_gps_nodelet that issues a FRESET command on the indicated target, or STANDARD if none is provided.