### PR TITLE
Fixes RPY orientation in IMU output (based on testing).

### DIFF
--- a/novatel_gps_driver/src/novatel_gps.cpp
+++ b/novatel_gps_driver/src/novatel_gps.cpp
@@ -922,8 +922,8 @@ namespace novatel_gps_driver
 
       imu->header.stamp = corrimudata->header.stamp;
       imu->orientation = tf::createQuaternionMsgFromRollPitchYaw(inspva->roll * DEGREES_TO_RADIANS,
-                                              inspva->pitch * DEGREES_TO_RADIANS,
-                                              (90.0 - inspva->azimuth) * DEGREES_TO_RADIANS);
+                                              -(inspva->pitch) * DEGREES_TO_RADIANS,
+                                              -(inspva->azimuth) * DEGREES_TO_RADIANS);
 
       if (latest_inscov_)
       {


### PR DESCRIPTION
During testing we noticed that the roll and pitch axes were swapped and the roll value (actually pitch) was inverse. This fix has been tested on a vehicle and appears to output both the correct roll and pitch.