### PR TITLE
Adds additional IMUs defined in the OEM7 firmware.

### DIFF
--- a/novatel_gps_driver/src/novatel_gps.cpp
+++ b/novatel_gps_driver/src/novatel_gps.cpp
@@ -1238,9 +1238,11 @@ namespace novatel_gps_driver
         { "34", std::pair<double, std::string>(200, "Northrop Grumman Litef ISA-100") },
         { "38", std::pair<double, std::string>(400, "Northrop Grumman Litef ISA-100 400Hz") },
         { "39", std::pair<double, std::string>(400, "Northrop Grumman Litef ISA-100C 400Hz") },
+        { "41", std::pair<double, std::string>(125, "Epson G320N") },
         { "45", std::pair<double, std::string>(200, "KVH 1725 IMU?") }, //(This was a guess based on the 1750
                        // as the actual rate is not documented and the specs are similar)
         { "52", std::pair<double, std::string>(200, "Litef microIMU") },
+        { "56", std::pair<double, std::string>(125, "Sensonor STIM300, Direct Connection") },
        };
       
       // Parse out the IMU type then save it, we don't care about the rest (3rd field)


### PR DESCRIPTION
This helps add support for the PowerPak7 series.

This has been tested and is working on a PowerPak 7 but other issues with the firmware API prevent it from working completely. Fixes for those will follow in a separate pull request.