### PR TITLE
Adds configuration parameter span_frame_to_ros_frame.

### DIFF
--- a/novatel_gps_driver/include/novatel_gps_driver/novatel_gps.h
+++ b/novatel_gps_driver/include/novatel_gps_driver/novatel_gps.h
@@ -232,6 +232,13 @@ namespace novatel_gps_driver
       static ConnectionType ParseConnection(const std::string& connection);
 
       /**
+       * @brief Determines whether or not to apply a 90 degree counter-clockwise rotation about Z
+       * to the Novatel SPAN frame to match up with the ROS coordinate frame.
+       * @param apply_rotation A bool indicating whether or not to apply the rotation.
+       */
+      void ApplyVehicleBodyRotation(const bool& apply_rotation);
+
+      /**
        * @brief Processes any data that has been received from the device since the last time
        * this message was called.  May result in any number of messages being placed in the
        * individual message buffers.
@@ -441,6 +448,9 @@ namespace novatel_gps_driver
       novatel_gps_msgs::InsstdevPtr latest_insstdev_;
       novatel_gps_msgs::InscovPtr latest_inscov_;
       double imu_rate_;
+
+      // Additional Options
+      bool apply_vehicle_body_rotation_;
   };
 }
 

--- a/novatel_gps_driver/src/nodelets/novatel_gps_nodelet.cpp
+++ b/novatel_gps_driver/src/nodelets/novatel_gps_nodelet.cpp
@@ -116,6 +116,9 @@
  *    messages.  [false]
  * \e wait_for_position <tt>bool</tt> - Wait for BESTPOS messages to arrive
  *    before publishing GPSFix messages. [false]
+ * \e span_frame_to_ros_frame <tt>bool</tt> - Translate the SPAN coordinate
+ *    frame to a ROS coordinate frame using the VEHICLEBODYROTATION and
+ *    APPLYVEHICLEBODYROTATION commands. [false]
  */
 #include <exception>
 #include <string>
@@ -180,6 +183,7 @@ namespace novatel_gps_driver
       publish_sync_diagnostic_(true),
       reconnect_delay_s_(0.5),
       use_binary_messages_(false),
+      span_frame_to_ros_frame_(false),
       connection_(NovatelGps::SERIAL),
       last_sync_(ros::TIME_MIN),
       rolling_offset_(stats::tag::rolling_window::window_size = 10),
@@ -228,6 +232,7 @@ namespace novatel_gps_driver
       swri::param(priv, "polling_period", polling_period_, polling_period_);
       swri::param(priv, "reconnect_delay_s", reconnect_delay_s_, reconnect_delay_s_);
       swri::param(priv, "use_binary_messages", use_binary_messages_, use_binary_messages_);
+      swri::param(priv, "span_frame_to_ros_frame", span_frame_to_ros_frame_, span_frame_to_ros_frame_);
 
       swri::param(priv, "connection_type", connection_type_, connection_type_);
       connection_ = NovatelGps::ParseConnection(connection_type_);
@@ -325,6 +330,9 @@ namespace novatel_gps_driver
               &NovatelGpsNodelet::SyncDiagnostic);
         }
       }
+
+      gps_.ApplyVehicleBodyRotation(span_frame_to_ros_frame_);
+
       thread_ = boost::thread(&NovatelGpsNodelet::Spin, this);
       NODELET_INFO("%s initialized", hw_id_.c_str());
     }
@@ -477,6 +485,7 @@ namespace novatel_gps_driver
     double imu_rate_;
     /// How frequently the device samples the IMU, in Hz
     double imu_sample_rate_;
+    bool span_frame_to_ros_frame_;
     bool publish_imu_messages_;
     bool publish_novatel_positions_;
     bool publish_novatel_velocity_;

--- a/novatel_gps_driver/src/novatel_gps.cpp
+++ b/novatel_gps_driver/src/novatel_gps.cpp
@@ -69,7 +69,8 @@ namespace novatel_gps_driver
       time_msgs_(MAX_BUFFER_SIZE),
       trackstat_msgs_(MAX_BUFFER_SIZE),
       imu_rate_(-1.0),
-      imu_rate_forced_(false)
+      imu_rate_forced_(false),
+      apply_vehicle_body_rotation_(false)
   {
   }
 
@@ -172,6 +173,11 @@ namespace novatel_gps_driver
       }
     }
     is_connected_ = false;
+  }
+
+  void NovatelGps::ApplyVehicleBodyRotation(const bool& apply_rotation)
+  {
+    apply_vehicle_body_rotation_ = apply_rotation;
   }
 
   NovatelGps::ReadResult NovatelGps::ProcessData()
@@ -1323,6 +1329,13 @@ namespace novatel_gps_driver
   {
     bool configured = true;
     configured = configured && Write("unlogall\n");
+
+    if (apply_vehicle_body_rotation_)
+    {
+      configured = configured && Write("vehiclebodyrotation 0 0 90\n");
+      configured = configured && Write("applyvehiclebodyrotation\n");
+    }
+
     for(NovatelMessageOpts::const_iterator option = opts.begin(); option != opts.end(); ++option)
     {
       std::stringstream command;


### PR DESCRIPTION
This configuration parameter will apply a VEHICLEBODYROTATION command
which rotates the Novatel SPAN frame 90 degrees counter-clockwise
about the Z axis and an APPLYVEHICLEBODYROTATION command to make
that rotation apply to the IMU and INS outputs. This converts the
Novatel SPAN frame (right-hand rule with Y forward) to a ROS frame
(right-hand rule with X forward).

Tested and works on OEM6 (should also work on OEM7 as the commands are the same).