### PR TITLE
Finish serial commands with [CR][LF] (Carriage-Return Line-Feed)

### DIFF
--- a/novatel_gps_driver/src/nodelets/novatel_gps_nodelet.cpp
+++ b/novatel_gps_driver/src/nodelets/novatel_gps_nodelet.cpp
@@ -571,7 +571,7 @@ namespace novatel_gps_driver
       // Formulate the reset command and send it to the device
       std::string command = "FRESET ";
       command += req.target.length() ? "STANDARD" : req.target;
-      command += '\n';
+      command += "\r\n";
       gps_.Write(command);
 
       if (req.target.length() == 0)

--- a/novatel_gps_driver/src/novatel_gps.cpp
+++ b/novatel_gps_driver/src/novatel_gps.cpp
@@ -1328,24 +1328,24 @@ namespace novatel_gps_driver
   bool NovatelGps::Configure(NovatelMessageOpts const& opts)
   {
     bool configured = true;
-    configured = configured && Write("unlogall\n");
+    configured = configured && Write("unlogall\r\n");
 
     if (apply_vehicle_body_rotation_)
     {
-      configured = configured && Write("vehiclebodyrotation 0 0 90\n");
-      configured = configured && Write("applyvehiclebodyrotation\n");
+      configured = configured && Write("vehiclebodyrotation 0 0 90\r\n");
+      configured = configured && Write("applyvehiclebodyrotation\r\n");
     }
 
     for(NovatelMessageOpts::const_iterator option = opts.begin(); option != opts.end(); ++option)
     {
       std::stringstream command;
       command << std::setprecision(3);
-      command << "log " << option->first << " ontime " << option->second << "\n";
+      command << "log " << option->first << " ontime " << option->second << "\r\n";
       configured = configured && Write(command.str());
     }
 
     // Log the IMU data once to get the IMU type
-    configured = configured && Write("log rawimuxa\n");
+    configured = configured && Write("log rawimuxa\r\n");
 
     return configured;
   }


### PR DESCRIPTION
With OEM4 models, [CR][LF] (\r\n) is the sequence used to mark the end
of command. Without this commands cannot be properly sent through
serial port.

Not sure if it would cause problems with a OEM6 or more recent model.

Did not test if this change would cause problems with other connection types, like for instance `TCP` and `UDP`, that seems to be the other connections that make a call to `NovatelGps::Configure`.