### PR TITLE
Feature bestutm

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ enabled.
             - Default: `false`
         - `publish_novatel_positions`: `true` to publish novatel_gps_msgs/NovatelPosition messages.
             - Default: `false`
+        - `publish_novatel_utm_positions`: `true` to publish novatel_gps_msgs/NovatelUtmPosition messages.
+            - Default: `false`
         - `publish_novatel_velocity`: `true` to publish novatel_gps_msgs/NovatelVelocity messages.
             - Default: `false`
         - `publish_range_messages`: `true` to publish novatel_gps_msgs/Range messages.
@@ -150,6 +152,7 @@ enabled.
     These are used to improve the accuracy of the time stamps of the messages published.
     3. **ROS Topic Publications**
         - `/bestpos` *(novatel_gps_msgs/NovatelPosition)*: [BESTPOS](http://docs.novatel.com/OEM7/Content/Logs/BESTPOS.htm) logs
+        - `/bestutm` *(novatel_gps_msgs/NovatelUtmPosition)*: [BESTUTM](http://docs.novatel.com/OEM7/Content/Logs/BESTUTM.htm) logs
         - `/bestvel` *(novatel_gps_msgs/NovatelVelocity)*: [BESTVEL](http://docs.novatel.com/OEM7/Content/Logs/BESTVEL.htm) logs
         - `/corrimudata` *(novatel_gps_msgs/NovatelCorrectedImuData)*: [CORRIMUDATA](http://docs.novatel.com/OEM7/Content/SPAN_Logs/CORRIMUDATA.htm) logs
         - `/diagnostics` *(diagnostic_msgs/DiagnosticArray)*: ROS diagnostics

--- a/novatel_gps_driver/CMakeLists.txt
+++ b/novatel_gps_driver/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library(${PROJECT_NAME}
   src/novatel_gps.cpp
   src/novatel_message_extractor.cpp
   src/parsers/bestpos.cpp
+  src/parsers/bestutm.cpp
   src/parsers/bestvel.cpp
   src/parsers/corrimudata.cpp
   src/parsers/gpgga.cpp

--- a/novatel_gps_driver/include/novatel_gps_driver/novatel_gps.h
+++ b/novatel_gps_driver/include/novatel_gps_driver/novatel_gps.h
@@ -51,6 +51,7 @@
 #include <novatel_gps_msgs/Insstdev.h>
 #include <novatel_gps_msgs/NovatelCorrectedImuData.h>
 #include <novatel_gps_msgs/NovatelPosition.h>
+#include <novatel_gps_msgs/NovatelUtmPosition.h>
 #include <novatel_gps_msgs/NovatelVelocity.h>
 #include <novatel_gps_msgs/Range.h>
 #include <novatel_gps_msgs/Time.h>
@@ -59,6 +60,7 @@
 #include <novatel_gps_driver/novatel_message_extractor.h>
 
 #include <novatel_gps_driver/parsers/bestpos.h>
+#include <novatel_gps_driver/parsers/bestutm.h>
 #include <novatel_gps_driver/parsers/bestvel.h>
 #include <novatel_gps_driver/parsers/corrimudata.h>
 #include <novatel_gps_driver/parsers/gpgga.h>
@@ -194,6 +196,12 @@ namespace novatel_gps_driver
        * @param[out] positions New BESTPOS messages.
        */
       void GetNovatelPositions(std::vector<novatel_gps_msgs::NovatelPositionPtr>& positions);
+      /**
+       * @brief Provides any BESTUTM messages that have been received since the
+       * last time this was called.
+       * @param[out] positions New BESTUTM messages.
+       */
+      void GetNovatelUtmPositions(std::vector<novatel_gps_msgs::NovatelUtmPositionPtr>& utm_positions);
       /**
        * @brief Provides any BESTVEL messages that have been received since the
        * last time this was called.
@@ -410,6 +418,7 @@ namespace novatel_gps_driver
 
       // Message parsers
       BestposParser bestpos_parser_;
+      BestutmParser bestutm_parser_;
       BestvelParser bestvel_parser_;
       CorrImuDataParser corrimudata_parser_;
       GpggaParser gpgga_parser_;
@@ -436,6 +445,7 @@ namespace novatel_gps_driver
       boost::circular_buffer<novatel_gps_msgs::InspvaPtr> inspva_msgs_;
       boost::circular_buffer<novatel_gps_msgs::InsstdevPtr> insstdev_msgs_;
       boost::circular_buffer<novatel_gps_msgs::NovatelPositionPtr> novatel_positions_;
+      boost::circular_buffer<novatel_gps_msgs::NovatelUtmPositionPtr> novatel_utm_positions_;
       boost::circular_buffer<novatel_gps_msgs::NovatelVelocityPtr> novatel_velocities_;
       boost::circular_buffer<novatel_gps_msgs::NovatelPositionPtr> position_sync_buffer_;
       boost::circular_buffer<novatel_gps_msgs::RangePtr> range_msgs_;

--- a/novatel_gps_driver/include/novatel_gps_driver/parsers/bestutm.h
+++ b/novatel_gps_driver/include/novatel_gps_driver/parsers/bestutm.h
@@ -1,0 +1,58 @@
+// *****************************************************************************
+//
+// Copyright (c) 2018, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL SOUTHWEST RESEARCH INSTITUTE BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+
+#ifndef NOVATEL_GPS_DRIVER_BESTUTM_H
+#define NOVATEL_GPS_DRIVER_BESTUTM_H
+
+#include <novatel_gps_msgs/NovatelUtmPosition.h>
+
+#include <novatel_gps_driver/parsers/parsing_utils.h>
+#include <novatel_gps_driver/parsers/message_parser.h>
+
+namespace novatel_gps_driver
+{
+  class BestutmParser : public MessageParser<novatel_gps_msgs::NovatelUtmPositionPtr>
+  {
+  public:
+    uint32_t GetMessageId() const override;
+
+    const std::string GetMessageName() const override;
+
+    novatel_gps_msgs::NovatelUtmPositionPtr ParseBinary(const BinaryMessage& bin_msg) throw(ParseException) override;
+
+    novatel_gps_msgs::NovatelUtmPositionPtr ParseAscii(const NovatelSentence& sentence) throw(ParseException) override;
+
+    static constexpr uint16_t MESSAGE_ID = 726;
+    static constexpr size_t BINARY_LENGTH = 80;
+    static constexpr size_t ASCII_LENGTH = 23;
+    static const std::string MESSAGE_NAME;
+  };
+}
+
+#endif //NOVATEL_GPS_DRIVER_BESTUTM_H

--- a/novatel_gps_driver/src/novatel_gps.cpp
+++ b/novatel_gps_driver/src/novatel_gps.cpp
@@ -63,6 +63,7 @@ namespace novatel_gps_driver
       inspva_msgs_(MAX_BUFFER_SIZE),
       insstdev_msgs_(MAX_BUFFER_SIZE),
       novatel_positions_(MAX_BUFFER_SIZE),
+      novatel_utm_positions_(MAX_BUFFER_SIZE),
       novatel_velocities_(MAX_BUFFER_SIZE),
       position_sync_buffer_(SYNC_BUFFER_SIZE),
       range_msgs_(MAX_BUFFER_SIZE),
@@ -290,6 +291,13 @@ namespace novatel_gps_driver
     positions.clear();
     positions.insert(positions.end(), novatel_positions_.begin(), novatel_positions_.end());
     novatel_positions_.clear();
+  }
+
+  void NovatelGps::GetNovatelUtmPositions(std::vector<novatel_gps_msgs::NovatelUtmPositionPtr>& utm_positions)
+  {
+    utm_positions.clear();
+    utm_positions.insert(utm_positions.end(), novatel_utm_positions_.begin(), novatel_utm_positions_.end());
+    novatel_utm_positions_.clear();
   }
 
   void NovatelGps::GetNovatelVelocities(std::vector<novatel_gps_msgs::NovatelVelocityPtr>& velocities)
@@ -993,6 +1001,13 @@ namespace novatel_gps_driver
         position_sync_buffer_.push_back(position);
         break;
       }
+      case BestutmParser::MESSAGE_ID:
+      {
+        novatel_gps_msgs::NovatelUtmPositionPtr utm_position = bestutm_parser_.ParseBinary(msg);
+        utm_position->header.stamp = stamp;
+        novatel_utm_positions_.push_back(utm_position);
+        break;
+      }
       case BestvelParser::MESSAGE_ID:
       {
         novatel_gps_msgs::NovatelVelocityPtr velocity = bestvel_parser_.ParseBinary(msg);
@@ -1154,6 +1169,12 @@ namespace novatel_gps_driver
       position->header.stamp = stamp;
       novatel_positions_.push_back(position);
       position_sync_buffer_.push_back(position);
+    }
+    if (sentence.id == "BESTUTMA")
+    {
+      novatel_gps_msgs::NovatelUtmPositionPtr utm_position = bestutm_parser_.ParseAscii(sentence);
+      utm_position->header.stamp = stamp;
+      novatel_utm_positions_.push_back(utm_position);
     }
     else if (sentence.id == "BESTVELA")
     {

--- a/novatel_gps_driver/src/parsers/bestutm.cpp
+++ b/novatel_gps_driver/src/parsers/bestutm.cpp
@@ -1,0 +1,166 @@
+// *****************************************************************************
+//
+// Copyright (c) 2018, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL SOUTHWEST RESEARCH INSTITUTE BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+
+#include <novatel_gps_driver/parsers/bestutm.h>
+
+#include <novatel_gps_driver/parsers/header.h>
+
+#include <boost/make_shared.hpp>
+
+namespace novatel_gps_driver
+{
+  const std::string BestutmParser::MESSAGE_NAME = "BESTUTM";
+
+  uint32_t BestutmParser::GetMessageId() const
+  {
+    return MESSAGE_ID;
+  }
+
+  const std::string BestutmParser::GetMessageName() const
+  {
+    return MESSAGE_NAME;
+  }
+
+  novatel_gps_msgs::NovatelUtmPositionPtr BestutmParser::ParseBinary(const BinaryMessage& bin_msg) throw(ParseException)
+  {
+    if (bin_msg.data_.size() != BINARY_LENGTH)
+    {
+      std::stringstream error;
+      error << "Unexpected BESTUTM message length: " << bin_msg.data_.size();
+      throw ParseException(error.str());
+    }
+    novatel_gps_msgs::NovatelUtmPositionPtr ros_msg =
+        boost::make_shared<novatel_gps_msgs::NovatelUtmPosition>();
+    HeaderParser header_parser;
+    ros_msg->novatel_msg_header = header_parser.ParseBinary(bin_msg);
+    ros_msg->novatel_msg_header.message_name = MESSAGE_NAME;
+
+    uint16_t solution_status = ParseUInt16(&bin_msg.data_[0]);
+    if (solution_status > MAX_SOLUTION_STATUS)
+    {
+      std::stringstream error;
+      error << "Unknown solution status: " << solution_status;
+      throw ParseException(error.str());
+    }
+    ros_msg->solution_status = SOLUTION_STATUSES[solution_status];
+    uint16_t pos_type = ParseUInt16(&bin_msg.data_[4]);
+    if (pos_type > MAX_POSITION_TYPE)
+    {
+      std::stringstream error;
+      error << "Unknown position type: " << pos_type;
+      throw ParseException(error.str());
+    }
+    ros_msg->position_type = POSITION_TYPES[pos_type];
+    ros_msg->lon_zone_number = ParseUInt32(&bin_msg.data_[8]);
+    ros_msg->lat_zone_letter = (char)ParseUInt32(&bin_msg.data_[12]);
+    ros_msg->northing = ParseDouble(&bin_msg.data_[16]);
+    ros_msg->easting = ParseDouble(&bin_msg.data_[24]);
+    ros_msg->height = ParseDouble(&bin_msg.data_[32]);
+    ros_msg->undulation = ParseFloat(&bin_msg.data_[40]);
+    uint16_t datum_id = ParseUInt16(&bin_msg.data_[44]);
+    if (datum_id > MAX_DATUM)
+    {
+      std::stringstream error;
+      error << "Unknown datum: " << datum_id;
+      throw ParseException(error.str());
+    }
+    ros_msg->datum_id = DATUMS[datum_id];
+    ros_msg->northing_sigma = ParseFloat(&bin_msg.data_[48]);
+    ros_msg->easting_sigma = ParseFloat(&bin_msg.data_[52]);
+    ros_msg->height_sigma = ParseFloat(&bin_msg.data_[56]);
+    ros_msg->base_station_id.resize(4);
+    std::copy(&bin_msg.data_[60], &bin_msg.data_[64], &ros_msg->base_station_id[0]);
+    ros_msg->diff_age = ParseFloat(&bin_msg.data_[64]);
+    ros_msg->solution_age = ParseFloat(&bin_msg.data_[68]);
+    ros_msg->num_satellites_tracked = bin_msg.data_[72];
+    ros_msg->num_satellites_used_in_solution = bin_msg.data_[73];
+    ros_msg->num_gps_and_glonass_l1_used_in_solution = bin_msg.data_[74];
+    ros_msg->num_gps_and_glonass_l1_and_l2_used_in_solution = bin_msg.data_[75];
+    GetExtendedSolutionStatusMessage(bin_msg.data_[77],
+                                     ros_msg->extended_solution_status);
+    GetSignalsUsed(bin_msg.data_[78], ros_msg->signal_mask);
+
+    return ros_msg;
+  }
+
+  novatel_gps_msgs::NovatelUtmPositionPtr BestutmParser::ParseAscii(const NovatelSentence& sentence) throw(ParseException)
+  {
+    novatel_gps_msgs::NovatelUtmPositionPtr msg =
+        boost::make_shared<novatel_gps_msgs::NovatelUtmPosition>();
+    HeaderParser h_parser;
+    msg->novatel_msg_header = h_parser.ParseAscii(sentence);
+
+    if (sentence.body.size() != ASCII_LENGTH)
+    {
+      std::stringstream error;
+      error << "Unexpected number of BESTUTM message fields: " << sentence.body.size();
+      throw ParseException(error.str());
+    }
+
+    bool valid = true;
+
+    msg->solution_status = sentence.body[0];
+    msg->position_type = sentence.body[1];
+    valid = valid && ParseUInt32(sentence.body[2], msg->lon_zone_number);
+    msg->lat_zone_letter = sentence.body[3];
+    valid = valid && ParseDouble(sentence.body[4], msg->northing);
+    valid = valid && ParseDouble(sentence.body[5], msg->easting);
+    valid = valid && ParseDouble(sentence.body[6], msg->height);
+    valid = valid && ParseFloat(sentence.body[7], msg->undulation);
+    msg->datum_id = sentence.body[8];
+    valid = valid && ParseFloat(sentence.body[9], msg->northing_sigma);
+    valid = valid && ParseFloat(sentence.body[10], msg->easting_sigma);
+    valid = valid && ParseFloat(sentence.body[11], msg->height_sigma);
+    msg->base_station_id = sentence.body[12];
+    valid = valid && ParseFloat(sentence.body[13], msg->diff_age);
+    valid = valid && ParseFloat(sentence.body[14], msg->solution_age);
+    valid = valid && ParseUInt8(sentence.body[15], msg->num_satellites_tracked);
+    valid = valid && ParseUInt8(sentence.body[16], msg->num_satellites_used_in_solution);
+    valid = valid && ParseUInt8(sentence.body[17], msg->num_gps_and_glonass_l1_used_in_solution);
+    valid = valid && ParseUInt8(sentence.body[18], msg->num_gps_and_glonass_l1_and_l2_used_in_solution);
+
+    // skip reserved field
+    uint32_t extended_solution_status = 0;
+    valid = valid && ParseUInt32(sentence.body[20], extended_solution_status, 16);
+    GetExtendedSolutionStatusMessage(
+        extended_solution_status, msg->extended_solution_status);
+
+    // skip reserved field (Galileo and BeiDou sig mask)
+    uint32_t signal_mask = 0;
+    valid = valid && ParseUInt32(sentence.body[22], signal_mask, 16);
+    GetSignalsUsed(signal_mask, msg->signal_mask);
+
+    if (!valid)
+    {
+      throw ParseException("Invalid field in BESTUTM message");
+    }
+
+    return msg;
+  }
+};

--- a/novatel_gps_msgs/CMakeLists.txt
+++ b/novatel_gps_msgs/CMakeLists.txt
@@ -26,6 +26,7 @@ add_message_files(DIRECTORY msg FILES
   NovatelExtendedSolutionStatus.msg
   NovatelMessageHeader.msg
   NovatelPosition.msg
+  NovatelUtmPosition.msg
   NovatelReceiverStatus.msg
   NovatelSignalMask.msg
   NovatelVelocity.msg

--- a/novatel_gps_msgs/msg/NovatelUtmPosition.msg
+++ b/novatel_gps_msgs/msg/NovatelUtmPosition.msg
@@ -1,0 +1,33 @@
+# Parsed Best UTM data from Novatel OEM6 receiver
+Header header
+
+NovatelMessageHeader novatel_msg_header
+
+string solution_status
+string position_type
+
+# Position Data
+uint32 lon_zone_number
+string lat_zone_letter
+float64 northing
+float64 easting
+float64 height
+
+float32 undulation
+string datum_id
+
+# Accuracy Statistics (units?)
+float32 northing_sigma
+float32 easting_sigma
+float32 height_sigma
+string base_station_id
+float32 diff_age
+float32 solution_age
+uint8 num_satellites_tracked
+uint8 num_satellites_used_in_solution
+uint8 num_gps_and_glonass_l1_used_in_solution
+uint8 num_gps_and_glonass_l1_and_l2_used_in_solution
+
+NovatelExtendedSolutionStatus extended_solution_status
+
+NovatelSignalMask signal_mask


### PR DESCRIPTION
This PR adds the option to publish BESTUTM logs in a form of the new message NovatelUtmPosition on the topic /bestutm, enabled through the ROS parameter `publish_novatel_utm_positions`.

Tested on a OEM6 GPS through USB connection.

I tried to be careful to mimic most of the code related to parsing, enabling and publishing Novatel positions, but since many files were changed I may have missed something. Please let me know if you spot something wrong/missing.