### PR TITLE
Feature select serial baud rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ enabled.
             - Default: `false`
         - `reconnect_delay_s`: Second delay between reconnection attempts.
             - Default: `0.5`
+        - `serial_baud`: Select the serial baud rate to be used in a serial connection.
+            - Default: `115200`
         - `use_binary_messages`: `true` to request binary NovAtel logs, `false` to request ASCII.
             - Binary logs are much more efficient and effectively required for IMU data,
             but ASCII logs are easier to parse for a human.

--- a/novatel_gps_driver/include/novatel_gps_driver/novatel_gps.h
+++ b/novatel_gps_driver/include/novatel_gps_driver/novatel_gps.h
@@ -254,6 +254,12 @@ namespace novatel_gps_driver
       void SetImuRate(double imu_rate, bool force = true);
 
       /**
+       * @brief Sets the serial baud rate; should be called before configuring a serial connection.
+       * @param serial_baud_rate The serial baud rate.
+       */
+      void SetSerialBaud(int32_t serial_baud);
+
+      /**
        * @brief Writes the given string of characters to a connected NovAtel device.
        * @param command A string to transmit.
        * @return true if we successfully wrote all of the data, false otherwise.
@@ -300,9 +306,9 @@ namespace novatel_gps_driver
       /**
        * @brief Establishes a serial port connection with a NovAtel device.
        *
-       * It will create a connection set at 115200 baud, no parity, no flow control, and
-       * 8N1 bits, then it will call Configure() on that connection.  After this
-       * method has succeeded, RedData() and Write() can be used to communicate with
+       * It will create a connection set at the baud set by SetSerialBaudRate(), no parity, 
+       * no flow control, and 8N1 bits, then it will call Configure() on that connection.  After
+       * this method has succeeded, RedData() and Write() can be used to communicate with
        * the device.
        *
        * @param device The device node to connect to; e. g., "/dev/ttyUSB0"
@@ -382,6 +388,7 @@ namespace novatel_gps_driver
       double utc_offset_;
 
       // Serial connection
+      int32_t serial_baud_;
       swri_serial_util::SerialPort serial_;
 
       // TCP / UDP connections

--- a/novatel_gps_driver/src/nodelets/novatel_gps_nodelet.cpp
+++ b/novatel_gps_driver/src/nodelets/novatel_gps_nodelet.cpp
@@ -236,6 +236,7 @@ namespace novatel_gps_driver
 
       swri::param(priv, "connection_type", connection_type_, connection_type_);
       connection_ = NovatelGps::ParseConnection(connection_type_);
+      swri::param(priv, "serial_baud", serial_baud_, 115200);
 
       swri::param(priv, "imu_frame_id", imu_frame_id_, std::string(""));
       swri::param(priv, "frame_id", frame_id_, std::string(""));
@@ -406,6 +407,11 @@ namespace novatel_gps_driver
       {
         opts["trackstat" + format_suffix] = 1.0;  // Trackstat
       }
+      // Set the serial baud rate if needed
+      if (connection_ == NovatelGps::SERIAL)
+      {
+        gps_.SetSerialBaud(serial_baud_);
+      }
       while (ros::ok())
       {
         if (gps_.Connect(device_, connection_, opts))
@@ -478,6 +484,8 @@ namespace novatel_gps_driver
     std::string device_;
     /// The connection type, ("serial", "tcp", or "udp")
     std::string connection_type_;
+    /// The baud rate used for serial connection
+    int32_t serial_baud_;
     double polling_period_;
     bool publish_gpgsa_;
     bool publish_gpgsv_;

--- a/novatel_gps_driver/src/novatel_gps.cpp
+++ b/novatel_gps_driver/src/novatel_gps.cpp
@@ -49,6 +49,7 @@ namespace novatel_gps_driver
       connection_(SERIAL),
       is_connected_(false),
       utc_offset_(0),
+      serial_baud_(115200),
       tcp_socket_(io_service_),
       pcap_(NULL),
       corrimudata_msgs_(MAX_BUFFER_SIZE),
@@ -535,7 +536,7 @@ namespace novatel_gps_driver
   bool NovatelGps::CreateSerialConnection(const std::string& device, NovatelMessageOpts const& opts)
   {
     swri_serial_util::SerialConfig config;
-    config.baud = 115200;
+    config.baud = serial_baud_;
     config.parity = swri_serial_util::SerialConfig::NO_PARITY;
     config.flow_control = false;
     config.data_bits = 8;
@@ -978,6 +979,12 @@ namespace novatel_gps_driver
     {
       imu_rate_forced_ = true;
     }
+  }
+
+  void NovatelGps::SetSerialBaud(int32_t serial_baud)
+  {
+    ROS_INFO("Serial baud rate : %d", serial_baud);
+    serial_baud_ = serial_baud;
   }
 
   NovatelGps::ReadResult NovatelGps::ParseBinaryMessage(const BinaryMessage& msg,


### PR DESCRIPTION
For the serial connections one may want to connect to the device in a baud rate other than 115200. This PR adds an option for the user to set the desired serial baud rate.

This is only important when connecting through the device serial ports. It seems to be irrelevant if you're using the device USB port, that emulates a serial connection behind the scenes but apparently handles the baud rate for you.

Tested with a OEM6 GPS.