### PR TITLE
Only unlogall for the current port

### DIFF
--- a/novatel_gps_driver/src/novatel_gps.cpp
+++ b/novatel_gps_driver/src/novatel_gps.cpp
@@ -1357,7 +1357,7 @@ namespace novatel_gps_driver
   bool NovatelGps::Configure(NovatelMessageOpts const& opts)
   {
     bool configured = true;
-    configured = configured && Write("unlogall\r\n");
+    configured = configured && Write("unlogall THISPORT_ALL\r\n");
 
     if (apply_vehicle_body_rotation_)
     {


### PR DESCRIPTION
This allows you to use multiple drivers to split the load between the different ports of the same gps. Before all of the topics produced by a device would be unlogged instead of just those on the interface used, causing conflicts.