### PR TITLE
Add support for BESTXYZ topic

### DIFF
--- a/novatel_gps_driver/CMakeLists.txt
+++ b/novatel_gps_driver/CMakeLists.txt
@@ -52,6 +52,7 @@ add_library(${PROJECT_NAME}
   src/parsers/bestpos.cpp
   src/parsers/bestutm.cpp
   src/parsers/bestvel.cpp
+  src/parsers/bestxyz.cpp
   src/parsers/corrimudata.cpp
   src/parsers/gpgga.cpp
   src/parsers/gpgsa.cpp

--- a/novatel_gps_driver/CMakeLists.txt
+++ b/novatel_gps_driver/CMakeLists.txt
@@ -68,6 +68,9 @@ add_library(${PROJECT_NAME}
   src/parsers/time.cpp
   src/parsers/trackstat.cpp
 )
+
+add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
+
 target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
   ${Boost_LIBRARIES}

--- a/novatel_gps_driver/include/novatel_gps_driver/novatel_gps.h
+++ b/novatel_gps_driver/include/novatel_gps_driver/novatel_gps.h
@@ -51,6 +51,7 @@
 #include <novatel_gps_msgs/Insstdev.h>
 #include <novatel_gps_msgs/NovatelCorrectedImuData.h>
 #include <novatel_gps_msgs/NovatelPosition.h>
+#include <novatel_gps_msgs/NovatelXYZ.h>
 #include <novatel_gps_msgs/NovatelUtmPosition.h>
 #include <novatel_gps_msgs/NovatelVelocity.h>
 #include <novatel_gps_msgs/Range.h>
@@ -60,6 +61,7 @@
 #include <novatel_gps_driver/novatel_message_extractor.h>
 
 #include <novatel_gps_driver/parsers/bestpos.h>
+#include <novatel_gps_driver/parsers/bestxyz.h>
 #include <novatel_gps_driver/parsers/bestutm.h>
 #include <novatel_gps_driver/parsers/bestvel.h>
 #include <novatel_gps_driver/parsers/corrimudata.h>
@@ -196,6 +198,12 @@ namespace novatel_gps_driver
        * @param[out] positions New BESTPOS messages.
        */
       void GetNovatelPositions(std::vector<novatel_gps_msgs::NovatelPositionPtr>& positions);
+      /**
+       * @brief Provides any BESTXYZ messages that have been received since the
+       * last time this was called.
+       * @param[out] positions New BESTXYZ messages.
+       */
+      void GetNovatelXYZPositions(std::vector<novatel_gps_msgs::NovatelXYZPtr>& positions);
       /**
        * @brief Provides any BESTUTM messages that have been received since the
        * last time this was called.
@@ -425,6 +433,7 @@ namespace novatel_gps_driver
 
       // Message parsers
       BestposParser bestpos_parser_;
+      BestxyzParser bestxyz_parser_;
       BestutmParser bestutm_parser_;
       BestvelParser bestvel_parser_;
       CorrImuDataParser corrimudata_parser_;
@@ -452,6 +461,7 @@ namespace novatel_gps_driver
       boost::circular_buffer<novatel_gps_msgs::InspvaPtr> inspva_msgs_;
       boost::circular_buffer<novatel_gps_msgs::InsstdevPtr> insstdev_msgs_;
       boost::circular_buffer<novatel_gps_msgs::NovatelPositionPtr> novatel_positions_;
+      boost::circular_buffer<novatel_gps_msgs::NovatelXYZPtr> novatel_xyz_positions_;
       boost::circular_buffer<novatel_gps_msgs::NovatelUtmPositionPtr> novatel_utm_positions_;
       boost::circular_buffer<novatel_gps_msgs::NovatelVelocityPtr> novatel_velocities_;
       boost::circular_buffer<novatel_gps_msgs::NovatelPositionPtr> position_sync_buffer_;

--- a/novatel_gps_driver/include/novatel_gps_driver/parsers/bestxyz.h
+++ b/novatel_gps_driver/include/novatel_gps_driver/parsers/bestxyz.h
@@ -1,0 +1,58 @@
+// *****************************************************************************
+//
+// Copyright (c) 2017, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL SOUTHWEST RESEARCH INSTITUTE BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+
+#ifndef NOVATEL_GPS_DRIVER_BESTXYZ_H
+#define NOVATEL_GPS_DRIVER_BESTXYZ_H
+
+#include <novatel_gps_msgs/NovatelXYZ.h>
+
+#include <novatel_gps_driver/parsers/parsing_utils.h>
+#include <novatel_gps_driver/parsers/message_parser.h>
+
+namespace novatel_gps_driver
+{
+  class BestxyzParser : public MessageParser<novatel_gps_msgs::NovatelXYZPtr>
+  {
+  public:
+    uint32_t GetMessageId() const override;
+
+    const std::string GetMessageName() const override;
+
+    novatel_gps_msgs::NovatelXYZPtr ParseBinary(const BinaryMessage& bin_msg) throw(ParseException) override;
+
+    novatel_gps_msgs::NovatelXYZPtr ParseAscii(const NovatelSentence& sentence) throw(ParseException) override;
+
+    static constexpr uint16_t MESSAGE_ID = 241;
+    static constexpr size_t BINARY_LENGTH = 112;
+    static constexpr size_t ASCII_LENGTH = 28;
+    static const std::string MESSAGE_NAME;
+  };
+}
+
+#endif //NOVATEL_GPS_DRIVER_BESTXYZ_H

--- a/novatel_gps_driver/src/nodelets/novatel_gps_nodelet.cpp
+++ b/novatel_gps_driver/src/nodelets/novatel_gps_nodelet.cpp
@@ -178,6 +178,7 @@ namespace novatel_gps_driver
       imu_sample_rate_(-1),
       publish_imu_messages_(false),
       publish_novatel_positions_(false),
+      publish_novatel_xyz_positions_(false),
       publish_novatel_utm_positions_(false),
       publish_novatel_velocity_(false),
       publish_nmea_messages_(false),
@@ -227,6 +228,7 @@ namespace novatel_gps_driver
       swri::param(priv, "publish_gpgsv", publish_gpgsv_, publish_gpgsv_);
       swri::param(priv, "publish_imu_messages", publish_imu_messages_, publish_imu_messages_);
       swri::param(priv, "publish_novatel_positions", publish_novatel_positions_, publish_novatel_positions_);
+      swri::param(priv, "publish_novatel_xyz_positions", publish_novatel_xyz_positions_, publish_novatel_xyz_positions_);
       swri::param(priv, "publish_novatel_utm_positions", publish_novatel_utm_positions_, publish_novatel_utm_positions_);
       swri::param(priv, "publish_novatel_velocity", publish_novatel_velocity_, publish_novatel_velocity_);
       swri::param(priv, "publish_nmea_messages", publish_nmea_messages_, publish_nmea_messages_);
@@ -289,6 +291,11 @@ namespace novatel_gps_driver
       if (publish_novatel_positions_)
       { 
         novatel_position_pub_ = swri::advertise<novatel_gps_msgs::NovatelPosition>(node, "bestpos", 100);
+      }
+
+      if (publish_novatel_xyz_positions_)
+      { 
+        novatel_xyz_position_pub_ = swri::advertise<novatel_gps_msgs::NovatelXYZ>(node, "bestxyz", 100);
       }
 
       if (publish_novatel_utm_positions_)
@@ -378,7 +385,10 @@ namespace novatel_gps_driver
       opts["gprmc"] = polling_period_;
       opts["bestpos" + format_suffix] = polling_period_;  // Best position
       opts["time" + format_suffix] = 1.0;  // Time
-
+      if (publish_novatel_xyz_positions_)
+      {
+        opts["bestxyz" + format_suffix] = polling_period_;
+      }
       if (publish_novatel_utm_positions_)
       {
         opts["bestutm" + format_suffix] = polling_period_;
@@ -511,6 +521,7 @@ namespace novatel_gps_driver
     bool span_frame_to_ros_frame_;
     bool publish_imu_messages_;
     bool publish_novatel_positions_;
+    bool publish_novatel_xyz_positions_;
     bool publish_novatel_utm_positions_;
     bool publish_novatel_velocity_;
     bool publish_nmea_messages_;
@@ -530,6 +541,7 @@ namespace novatel_gps_driver
     ros::Publisher insstdev_pub_;
     ros::Publisher novatel_imu_pub_;
     ros::Publisher novatel_position_pub_;
+    ros::Publisher novatel_xyz_position_pub_;
     ros::Publisher novatel_utm_pub_;
     ros::Publisher novatel_velocity_pub_;
     ros::Publisher gpgga_pub_;
@@ -617,6 +629,7 @@ namespace novatel_gps_driver
     void CheckDeviceForData()
     {
       std::vector<novatel_gps_msgs::NovatelPositionPtr> position_msgs;
+      std::vector<novatel_gps_msgs::NovatelXYZPtr> xyz_position_msgs;
       std::vector<novatel_gps_msgs::NovatelUtmPositionPtr> utm_msgs;
       std::vector<gps_common::GPSFixPtr> fix_msgs;
       std::vector<novatel_gps_msgs::GpggaPtr> gpgga_msgs;
@@ -659,6 +672,7 @@ namespace novatel_gps_driver
       gps_.GetGpggaMessages(gpgga_msgs);
       gps_.GetGprmcMessages(gprmc_msgs);
       gps_.GetNovatelPositions(position_msgs);
+      gps_.GetNovatelXYZPositions(xyz_position_msgs);
       gps_.GetNovatelUtmPositions(utm_msgs);
       gps_.GetFixMessages(fix_msgs);
 
@@ -752,6 +766,16 @@ namespace novatel_gps_driver
           msg->header.stamp += sync_offset;
           msg->header.frame_id = frame_id_;
           novatel_position_pub_.publish(msg);
+        }
+      }
+
+      if (publish_novatel_xyz_positions_)
+      {
+        for (const auto& msg : xyz_position_msgs)
+        {
+          msg->header.stamp += sync_offset;
+          msg->header.frame_id = frame_id_;
+          novatel_xyz_position_pub_.publish(msg);
         }
       }
 

--- a/novatel_gps_driver/src/novatel_gps.cpp
+++ b/novatel_gps_driver/src/novatel_gps.cpp
@@ -64,6 +64,7 @@ namespace novatel_gps_driver
       inspva_msgs_(MAX_BUFFER_SIZE),
       insstdev_msgs_(MAX_BUFFER_SIZE),
       novatel_positions_(MAX_BUFFER_SIZE),
+      novatel_xyz_positions_(MAX_BUFFER_SIZE),
       novatel_utm_positions_(MAX_BUFFER_SIZE),
       novatel_velocities_(MAX_BUFFER_SIZE),
       position_sync_buffer_(SYNC_BUFFER_SIZE),
@@ -292,6 +293,13 @@ namespace novatel_gps_driver
     positions.clear();
     positions.insert(positions.end(), novatel_positions_.begin(), novatel_positions_.end());
     novatel_positions_.clear();
+  }
+
+  void NovatelGps::GetNovatelXYZPositions(std::vector<novatel_gps_msgs::NovatelXYZPtr>& positions)
+  {
+    positions.clear();
+    positions.insert(positions.end(), novatel_xyz_positions_.begin(), novatel_xyz_positions_.end());
+    novatel_xyz_positions_.clear();
   }
 
   void NovatelGps::GetNovatelUtmPositions(std::vector<novatel_gps_msgs::NovatelUtmPositionPtr>& utm_positions)
@@ -1008,6 +1016,13 @@ namespace novatel_gps_driver
         position_sync_buffer_.push_back(position);
         break;
       }
+      case BestxyzParser::MESSAGE_ID:
+      {
+        novatel_gps_msgs::NovatelXYZPtr xyz_position = bestxyz_parser_.ParseBinary(msg);
+        xyz_position->header.stamp = stamp;
+        novatel_xyz_positions_.push_back(xyz_position);
+        break;
+      }
       case BestutmParser::MESSAGE_ID:
       {
         novatel_gps_msgs::NovatelUtmPositionPtr utm_position = bestutm_parser_.ParseBinary(msg);
@@ -1176,6 +1191,12 @@ namespace novatel_gps_driver
       position->header.stamp = stamp;
       novatel_positions_.push_back(position);
       position_sync_buffer_.push_back(position);
+    }
+    if (sentence.id == "BESTXYZ")
+    {
+      novatel_gps_msgs::NovatelXYZPtr position = bestxyz_parser_.ParseAscii(sentence);
+      position->header.stamp = stamp;
+      novatel_xyz_positions_.push_back(position);
     }
     if (sentence.id == "BESTUTMA")
     {

--- a/novatel_gps_driver/src/parsers/bestxyz.cpp
+++ b/novatel_gps_driver/src/parsers/bestxyz.cpp
@@ -1,0 +1,203 @@
+// *****************************************************************************
+//
+// Copyright (c) 2017, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL SOUTHWEST RESEARCH INSTITUTE BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+
+#include <novatel_gps_driver/parsers/bestxyz.h>
+
+#include <novatel_gps_driver/parsers/header.h>
+
+#include <boost/make_shared.hpp>
+
+namespace novatel_gps_driver
+{
+  const std::string BestxyzParser::MESSAGE_NAME = "BESTXYZ";
+
+  uint32_t BestxyzParser::GetMessageId() const
+  {
+    return MESSAGE_ID;
+  }
+
+  const std::string BestxyzParser::GetMessageName() const
+  {
+    return MESSAGE_NAME;
+  }
+
+  novatel_gps_msgs::NovatelXYZPtr BestxyzParser::ParseBinary(const BinaryMessage& bin_msg) throw(ParseException) 
+  {
+    if (bin_msg.data_.size() != BINARY_LENGTH)
+    {
+      std::stringstream error;
+      error << "Unexpected BESTXYZ message length: " << bin_msg.data_.size();
+      throw ParseException(error.str());
+    }
+    novatel_gps_msgs::NovatelXYZPtr ros_msg =
+        boost::make_shared<novatel_gps_msgs::NovatelXYZ>();
+    HeaderParser header_parser;
+    ros_msg->novatel_msg_header = header_parser.ParseBinary(bin_msg);
+    ros_msg->novatel_msg_header.message_name = MESSAGE_NAME;
+
+    uint16_t solution_status = ParseUInt16(&bin_msg.data_[0]);
+    if (solution_status > MAX_SOLUTION_STATUS)
+    {
+      std::stringstream error;
+      error << "Unknown solution status: " << solution_status;
+      throw ParseException(error.str());
+    }
+    ros_msg->solution_status = SOLUTION_STATUSES[solution_status];
+    
+    uint16_t pos_type = ParseUInt16(&bin_msg.data_[4]);
+    if (pos_type > MAX_POSITION_TYPE)
+    {
+      std::stringstream error;
+      error << "Unknown position type: " << pos_type;
+      throw ParseException(error.str());
+    }
+    ros_msg->position_type = POSITION_TYPES[pos_type];
+
+    ros_msg->x = ParseDouble(&bin_msg.data_[8]);
+    ros_msg->y = ParseDouble(&bin_msg.data_[16]);
+    ros_msg->z = ParseDouble(&bin_msg.data_[24]);
+
+    ros_msg->x_sigma = ParseFloat(&bin_msg.data_[32]);
+    ros_msg->y_sigma = ParseFloat(&bin_msg.data_[36]);
+    ros_msg->z_sigma = ParseFloat(&bin_msg.data_[40]);
+
+    uint16_t vel_solution_status = ParseUInt16(&bin_msg.data_[44]);
+    if (vel_solution_status > MAX_SOLUTION_STATUS)
+    {
+      std::stringstream error;
+      error << "Unknown solution status: " << vel_solution_status;
+      throw ParseException(error.str());
+    }
+    ros_msg->velocity_solution_status = SOLUTION_STATUSES[vel_solution_status];
+
+    uint16_t vel_type = ParseUInt16(&bin_msg.data_[48]);
+    if (vel_type > MAX_POSITION_TYPE) // Position types array includes velocity types
+    {
+      std::stringstream error;
+      error << "Unknown position type: " << vel_type;
+      throw ParseException(error.str());
+    }
+    ros_msg->velocity_type = POSITION_TYPES[vel_type];
+
+    ros_msg->x_vel = ParseDouble(&bin_msg.data_[52]);
+    ros_msg->y_vel = ParseDouble(&bin_msg.data_[60]);
+    ros_msg->z_vel = ParseDouble(&bin_msg.data_[68]);
+
+    ros_msg->x_vel_sigma = ParseFloat(&bin_msg.data_[76]);
+    ros_msg->y_vel_sigma = ParseFloat(&bin_msg.data_[80]);
+    ros_msg->z_vel_sigma = ParseFloat(&bin_msg.data_[84]);
+
+    ros_msg->base_station_id.resize(4);
+    std::copy(&bin_msg.data_[88], &bin_msg.data_[92], &ros_msg->base_station_id[0]);
+
+    ros_msg->velocity_latency = ParseFloat(&bin_msg.data_[92]);
+
+    ros_msg->diff_age = ParseFloat(&bin_msg.data_[96]);
+    ros_msg->solution_age = ParseFloat(&bin_msg.data_[100]);
+
+    ros_msg->num_satellites_tracked = bin_msg.data_[104];
+    ros_msg->num_satellites_used_in_solution = bin_msg.data_[105];
+    ros_msg->num_gps_and_glonass_l1_used_in_solution = bin_msg.data_[106];
+    ros_msg->num_gps_and_glonass_l1_and_l2_used_in_solution = bin_msg.data_[107];
+    // Byte 108 is reserved
+    GetExtendedSolutionStatusMessage(bin_msg.data_[109],
+                                     ros_msg->extended_solution_status);
+    // Byte 110 is reserved
+    GetSignalsUsed(bin_msg.data_[111], ros_msg->signal_mask);
+
+    return ros_msg;
+  }
+
+  novatel_gps_msgs::NovatelXYZPtr BestxyzParser::ParseAscii(const NovatelSentence& sentence) throw(ParseException)
+  {
+    novatel_gps_msgs::NovatelXYZPtr msg =
+        boost::make_shared<novatel_gps_msgs::NovatelXYZ>();
+    HeaderParser h_parser;
+    msg->novatel_msg_header = h_parser.ParseAscii(sentence);
+
+    if (sentence.body.size() != ASCII_LENGTH)
+    {
+      std::stringstream error;
+      error << "Unexpected number of BESTXYZ message fields: " << sentence.body.size();
+      throw ParseException(error.str());
+    }
+
+    bool valid = true;
+
+    msg->solution_status = sentence.body[0];
+    msg->position_type = sentence.body[1];
+    
+    valid = valid && ParseDouble(sentence.body[2], msg->x);
+    valid = valid && ParseDouble(sentence.body[3], msg->y);
+    valid = valid && ParseDouble(sentence.body[4], msg->z);
+
+    valid = valid && ParseFloat(sentence.body[5], msg->x_sigma);
+    valid = valid && ParseFloat(sentence.body[6], msg->y_sigma);
+    valid = valid && ParseFloat(sentence.body[7], msg->z_sigma);
+
+    msg->velocity_solution_status = sentence.body[8];
+    msg->velocity_type = sentence.body[9];
+
+    valid = valid && ParseDouble(sentence.body[10], msg->x_vel);
+    valid = valid && ParseDouble(sentence.body[11], msg->y_vel);
+    valid = valid && ParseDouble(sentence.body[12], msg->z_vel);
+
+    valid = valid && ParseFloat(sentence.body[13], msg->x_vel_sigma);
+    valid = valid && ParseFloat(sentence.body[14], msg->y_vel_sigma);
+    valid = valid && ParseFloat(sentence.body[15], msg->z_vel_sigma);
+
+    msg->base_station_id = sentence.body[16];
+    valid = valid && ParseFloat(sentence.body[17], msg->velocity_latency);
+    
+    valid = valid && ParseFloat(sentence.body[18], msg->diff_age);
+    valid = valid && ParseFloat(sentence.body[19], msg->solution_age);
+    valid = valid && ParseUInt8(sentence.body[20], msg->num_satellites_tracked);
+    valid = valid && ParseUInt8(sentence.body[21], msg->num_satellites_used_in_solution);
+    valid = valid && ParseUInt8(sentence.body[22], msg->num_gps_and_glonass_l1_used_in_solution);
+    valid = valid && ParseUInt8(sentence.body[23], msg->num_gps_and_glonass_l1_and_l2_used_in_solution);
+
+    // skip reserved field
+    uint32_t extended_solution_status = 0;
+    valid = valid && ParseUInt32(sentence.body[25], extended_solution_status, 16);
+    GetExtendedSolutionStatusMessage(
+        extended_solution_status, msg->extended_solution_status);
+
+    // skip reserved field
+    uint32_t signal_mask = 0;
+    valid = valid && ParseUInt32(sentence.body[27], signal_mask, 16);
+    GetSignalsUsed(signal_mask, msg->signal_mask);
+
+    if (!valid)
+    {
+      throw ParseException("Invalid field in BESTXYZ message");
+    }
+
+    return msg;
+  }
+};

--- a/novatel_gps_driver/test/parser_tests.cpp
+++ b/novatel_gps_driver/test/parser_tests.cpp
@@ -30,6 +30,7 @@
 #include <novatel_gps_driver/parsers/bestpos.h>
 #include <novatel_gps_driver/parsers/gpgsv.h>
 #include <novatel_gps_driver/novatel_message_extractor.h>
+#include <novatel_gps_driver/parsers/bestxyz.h>
 
 #include <gtest/gtest.h>
 #include <novatel_gps_driver/parsers/inspva.h>
@@ -289,6 +290,65 @@ TEST(ParserTestSuite, testInsstdevAsciiParsing)
   ASSERT_FLOAT_EQ(3.7534, msg->pitch_dev);
   ASSERT_FLOAT_EQ(5.1857, msg->azimuth_dev);
   ASSERT_EQ(26000005, msg->extended_solution_status.original_mask);
+}
+
+TEST(ParserTestSuite, testBestxyzAsciiParsing)
+{
+  novatel_gps_driver::BestxyzParser parser;
+  std::string bestxyz_str = "#BESTXYZA,COM1,0,55.0,FINESTEERING,1419,340033.000,02000040,d821,2724;"
+  "SOL_COMPUTED,NARROW_INT,-1634531.5683,-3664618.0326,4942496.3270,0.0099,"
+  "0.0219,0.0115,SOL_COMPUTED,NARROW_INT,0.0011,-0.0049,-0.0001,0.0199,0.0439,"
+  "0.0230,\"AAAA\",0.250,1.000,0.000,12,11,11,11,0,01,0,33*1fe2f509\r\n";
+
+  std::string extracted_str;
+
+  novatel_gps_driver::NovatelMessageExtractor extractor;
+
+  std::vector<novatel_gps_driver::NmeaSentence> nmea_sentences;
+  std::vector<novatel_gps_driver::NovatelSentence> novatel_sentences;
+  std::vector<novatel_gps_driver::BinaryMessage> binary_messages;
+  std::string remaining;
+
+  extractor.ExtractCompleteMessages(bestxyz_str, nmea_sentences, novatel_sentences,
+                                    binary_messages, remaining);
+
+  ASSERT_EQ(0, nmea_sentences.size());
+  ASSERT_EQ(0, binary_messages.size());
+  ASSERT_EQ(1, novatel_sentences.size());
+
+  novatel_gps_driver::NovatelSentence sentence = novatel_sentences.front();
+
+  ASSERT_EQ(parser.GetMessageName() + "A", sentence.id);
+
+  novatel_gps_msgs::NovatelXYZPtr msg = parser.ParseAscii(sentence);
+
+  ASSERT_NE(msg.get(), nullptr);
+
+  ASSERT_EQ("SOL_COMPUTED", msg->solution_status);
+  ASSERT_EQ("NARROW_INT", msg->position_type);
+  ASSERT_DOUBLE_EQ(-1634531.5683, msg->x);
+  ASSERT_DOUBLE_EQ(-3664618.0326, msg->y);
+  ASSERT_DOUBLE_EQ(4942496.3270, msg->z);
+  ASSERT_FLOAT_EQ(0.0099, msg->x_sigma);
+  ASSERT_FLOAT_EQ(0.0219, msg->y_sigma);
+  ASSERT_FLOAT_EQ(0.0115, msg->z_sigma);
+  ASSERT_EQ("SOL_COMPUTED", msg->velocity_solution_status);
+  ASSERT_EQ("NARROW_INT", msg->velocity_type);
+  ASSERT_DOUBLE_EQ(0.0011, msg->x_vel);
+  ASSERT_DOUBLE_EQ(-0.0049, msg->y_vel);
+  ASSERT_DOUBLE_EQ(-0.0001, msg->z_vel);
+  ASSERT_FLOAT_EQ(0.0199, msg->x_vel_sigma);
+  ASSERT_FLOAT_EQ(0.0439, msg->y_vel_sigma);
+  ASSERT_FLOAT_EQ(0.0230, msg->z_vel_sigma);
+  ASSERT_EQ("\"AAAA\"", msg->base_station_id);
+  ASSERT_FLOAT_EQ(0.250, msg->velocity_latency);
+  ASSERT_FLOAT_EQ(1.000, msg->diff_age);
+  ASSERT_FLOAT_EQ(0.000, msg->solution_age);
+  ASSERT_EQ(12, msg->num_satellites_tracked);
+  ASSERT_EQ(11, msg->num_satellites_used_in_solution);
+  ASSERT_EQ(11, msg->num_gps_and_glonass_l1_used_in_solution);
+  ASSERT_EQ(11, msg->num_gps_and_glonass_l1_and_l2_used_in_solution);
+  ASSERT_EQ(1, msg->extended_solution_status.original_mask);
 }
 
 int main(int argc, char **argv)

--- a/novatel_gps_msgs/CMakeLists.txt
+++ b/novatel_gps_msgs/CMakeLists.txt
@@ -31,6 +31,7 @@ add_message_files(DIRECTORY msg FILES
   NovatelReceiverStatus.msg
   NovatelSignalMask.msg
   NovatelVelocity.msg
+  NovatelXYZ.msg
   RangeInformation.msg
   Range.msg
   Satellite.msg

--- a/novatel_gps_msgs/msg/NovatelXYZ.msg
+++ b/novatel_gps_msgs/msg/NovatelXYZ.msg
@@ -1,0 +1,49 @@
+# Parsed Best Position in the WGS-84 ECEF frame from Novatel receiver
+Header header
+
+NovatelMessageHeader novatel_msg_header
+
+# Position Data (m)
+string solution_status
+string position_type
+
+float64 x
+float64 y
+float64 z
+
+# Position Standard Deviation (m)
+float32 x_sigma
+float32 y_sigma
+float32 z_sigma
+
+# Velocity Data
+string velocity_solution_status
+string velocity_type
+
+float64 x_vel
+float64 y_vel
+float64 z_vel
+
+# Velocity Standard Deviation (m/s)
+float32 x_vel_sigma
+float32 y_vel_sigma
+float32 z_vel_sigma
+
+string base_station_id
+float32 velocity_latency
+
+# Data Ages (sec)
+float32 diff_age
+float32 solution_age
+
+# Satellite Usage
+uint8 num_satellites_tracked
+uint8 num_satellites_used_in_solution
+uint8 num_gps_and_glonass_l1_used_in_solution
+uint8 num_gps_and_glonass_l1_and_l2_used_in_solution
+
+# Extended Solution Status
+NovatelExtendedSolutionStatus extended_solution_status
+
+# Signal Masks
+NovatelSignalMask signal_mask


### PR DESCRIPTION
The NovATel OEM7 specification includes a BESTXYZ message which reports the location of the vehicle in an ECEF frame. This PR adds support for this message type by adding a NovatelXYZ.msg file and the associated parser (bestxyz.h/.cpp). The messages are published to the /bestxyz topic. This was tested on a NovATel PwrPak7. 

The BESTXYZ message spec
https://docs.novatel.com/OEM7/Content/Logs/BESTXYZ.htm?tocpath=Logs%7CView%20Logs%7CGNSS%20Logs%7C_____18
