### PR TITLE
Fix ascii header message id in novatel_gps.cpp

### DIFF
--- a/novatel_gps_driver/src/novatel_gps.cpp
+++ b/novatel_gps_driver/src/novatel_gps.cpp
@@ -1228,7 +1228,7 @@ namespace novatel_gps_driver
       novatel_positions_.push_back(position);
       position_sync_buffer_.push_back(position);
     }
-    else if (sentence.id == "BESTXYZ")
+    else if (sentence.id == "BESTXYZA")
     {
       novatel_gps_msgs::NovatelXYZPtr position = bestxyz_parser_.ParseAscii(sentence);
       position->header.stamp = stamp;
@@ -1246,13 +1246,13 @@ namespace novatel_gps_driver
       velocity->header.stamp = stamp;
       novatel_velocities_.push_back(velocity);
     }
-    else if (sentence.id == "HEADING2")
+    else if (sentence.id == "HEADING2A")
     {
       novatel_gps_msgs::NovatelHeading2Ptr heading = heading2_parser_.ParseAscii(sentence);
       heading->header.stamp = stamp;
       heading2_msgs_.push_back(heading);
     }
-    else if (sentence.id == "DUALANTENNAHEADING")
+    else if (sentence.id == "DUALANTENNAHEADINGA")
     {
       novatel_gps_msgs::NovatelDualAntennaHeadingPtr heading = dual_antenna_heading_parser_.ParseAscii(sentence);
       heading->header.stamp = stamp;


### PR DESCRIPTION
In the recent PRs to add BESTXYZ, HEADING2, and DUALANTENNAHEADING messages the ASCII message id was missing the "A" on the end. This PR corrects that mistake so ASCII parsing with real hardware should work for those message types now. 