### PR TITLE
Use GPGGA quality to set GPSFix status

### DIFF
--- a/novatel_gps_driver/src/novatel_message_extractor.cpp
+++ b/novatel_gps_driver/src/novatel_message_extractor.cpp
@@ -583,7 +583,19 @@ namespace novatel_gps_driver
     gps_fix->track = gprmc.track;
     // gps_fix.vdop = ERR_INIT_HIGH;
 
-    gps_fix->status.status = gps_common::GPSStatus::STATUS_FIX;
+    switch (gpgga.gps_qual)
+    {
+      case novatel_gps_msgs::Gpgga::GPS_QUAL_INVALID:
+        gps_fix->status.status = gps_common::GPSStatus::STATUS_NO_FIX;
+        break;
+      case novatel_gps_msgs::Gpgga::GPS_QUAL_WASS:
+        gps_fix->status.status = gps_common::GPSStatus::STATUS_WAAS_FIX;
+        break;
+      default:
+        // Other statuses don't seem to have an exact equivalent, so map them all to STATUS_FIX
+        gps_fix->status.status = gps_common::GPSStatus::STATUS_FIX;
+        break;
+    }
     gps_fix->status.satellites_used = static_cast<uint16_t>(gpgga.num_sats);
 
   }

--- a/novatel_gps_driver/src/parsers/gpgga.cpp
+++ b/novatel_gps_driver/src/parsers/gpgga.cpp
@@ -110,16 +110,12 @@ novatel_gps_msgs::GpggaPtr novatel_gps_driver::GpggaParser::ParseAscii(const nov
 
   if (!valid)
   {
+    was_last_gps_valid_ = false;
     throw ParseException("GPGGA log was invalid.");
   }
 
-  // Check for actual lat and lon data
-  if (sentence.body[2].empty() || sentence.body[4].empty())
-  {
-    // No Lat or Lon data, return false;
-    was_last_gps_valid_ = false;
-  }
-
+  // If we got this far, we successfully parsed the message and will consider
+  // it valid
   was_last_gps_valid_ = true;
 
   return msg;

--- a/novatel_gps_msgs/msg/Gpgga.msg
+++ b/novatel_gps_msgs/msg/Gpgga.msg
@@ -1,4 +1,5 @@
 # Message from GPGGA NMEA String
+# Based on https://docs.novatel.com/OEM7/Content/Logs/GPGGA.htm
 Header header
 
 string message_id
@@ -12,6 +13,15 @@ float64 lon
 string lat_dir
 string lon_dir
 
+uint32 GPS_QUAL_INVALID=0
+uint32 GPS_QUAL_SINGLE_POINT=1
+uint32 GPS_QUAL_PSEUDORANGE_DIFFERENTIAL=2
+uint32 GPS_QUAL_RTK_FIXED_AMBIGUITY_SOLUTION=4
+uint32 GPS_QUAL_RTK_FLOATING_AMBIGUITY_SOLUTION=5
+uint32 GPS_QUAL_DEAD_RECKONING_MODE=6
+uint32 GPS_QUAL_MANUAL_INPUT_MODE=7
+uint32 GPS_QUAL_SIMULATION_MODE=8
+uint32 GPS_QUAL_WASS=9
 uint32 gps_qual
 
 uint32 num_sats
@@ -23,3 +33,4 @@ float32 undulation
 string undulation_units
 uint32 diff_age
 string station_id
+


### PR DESCRIPTION
This adds enums to the Gpgga message to represent all of the different
possible qualities, and it will also use the quality of GPGGA logs in
order to set the status of the GPSFix message.  It also adds a unit
test to verify that GPGGA logs are being parsed properly.

Fixes #47 