### PR TITLE
Add epson g370

### DIFF
--- a/novatel_gps_driver/src/novatel_gps.cpp
+++ b/novatel_gps_driver/src/novatel_gps.cpp
@@ -606,7 +606,7 @@ namespace novatel_gps_driver
       if (!Configure(opts))
       {
         // We will not kill the connection here, because the device may already
-        // be setup to communicate correctly, but we will print a warning         
+        // be setup to communicate correctly, but we will print a warning
         ROS_ERROR("Failed to configure GPS. This port may be read only, or the "
                  "device may not be functioning as expected; however, the "
                  "driver may still function correctly if the port has already "
@@ -1381,19 +1381,20 @@ namespace novatel_gps_driver
         { "52", std::pair<double, std::string>(200, "Litef microIMU") },
         { "56", std::pair<double, std::string>(125, "Sensonor STIM300, Direct Connection") },
         { "58", std::pair<double, std::string>(200, "Honeywell HG4930 AN01") },
+        { "61", std::pair<double, std::string>(100, "Epson G370") },
        };
-      
+
       // Parse out the IMU type then save it, we don't care about the rest (3rd field)
       std::string id = sentence.body.size() > 1 ? sentence.body[1] : "";
       if (rates.find(id) != rates.end())
       {
         double rate = rates[id].first;
- 
+
         ROS_INFO("IMU Type %s Found, Rate: %f Hz", rates[id].second.c_str(), (float)rate);
-        
+
         // Set the rate only if it hasn't been forced already
         if (!imu_rate_forced_)
-        {        
+        {
           SetImuRate(rate, false); // Dont force set from here so it can be configured elsewhere
         }
       }

--- a/novatel_gps_driver/src/novatel_gps.cpp
+++ b/novatel_gps_driver/src/novatel_gps.cpp
@@ -1381,7 +1381,7 @@ namespace novatel_gps_driver
         { "52", std::pair<double, std::string>(200, "Litef microIMU") },
         { "56", std::pair<double, std::string>(125, "Sensonor STIM300, Direct Connection") },
         { "58", std::pair<double, std::string>(200, "Honeywell HG4930 AN01") },
-        { "61", std::pair<double, std::string>(100, "Epson G370") },
+        { "61", std::pair<double, std::string>(100, "Epson G370N") },
        };
 
       // Parse out the IMU type then save it, we don't care about the rest (3rd field)


### PR DESCRIPTION
This PR adds the Epson 370N IMU.

According to the [docs](https://docs.novatel.com/OEM7/Content/SPAN_Logs/RAWIMU.htm?Highlight=rawimu), the 370N sample rate is 200 Hz. However, OEM7 reports [CORRIMUDATA](https://docs.novatel.com/OEM7/Content/SPAN_Logs/CORRIMUDATA.htm?Highlight=CORRIMUDATA) while accounting for the imu message logging rate, not the imu sample rate. So I'm not sure what to set for the rate associated with the 370N.

Do you think it would make sense to add an OEM7 flag or something that treats this rate setting differently for OEM7?