### PR TITLE
Add dependency on tf2_geometry_msgs

### DIFF
--- a/novatel_gps_driver/CMakeLists.txt
+++ b/novatel_gps_driver/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(swri_math_util  REQUIRED)
 find_package(swri_roscpp REQUIRED)
 find_package(swri_serial_util REQUIRED)
 find_package(tf2 REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 
 # Boost
 find_package(Boost REQUIRED COMPONENTS system thread)
@@ -78,6 +79,7 @@ ament_target_dependencies(${PROJECT_NAME}
   swri_roscpp
   swri_serial_util
   tf2
+  tf2_geometry_msgs
 )
 
 ### ROS Node ###

--- a/novatel_gps_driver/package.xml
+++ b/novatel_gps_driver/package.xml
@@ -28,6 +28,7 @@
   <depend>swri_roscpp</depend>
   <depend>swri_serial_util</depend>
   <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
The tf2 package depends on headers from this but does not actually
list it as a dependency; see ros/geometry2#275