### PR TITLE
Use ros::WallRate to sleep instead of boost

### DIFF
--- a/novatel_gps_driver/src/nodelets/novatel_gps_nodelet.cpp
+++ b/novatel_gps_driver/src/nodelets/novatel_gps_nodelet.cpp
@@ -530,7 +530,7 @@ namespace novatel_gps_driver
             // Spin once to let the ROS callbacks fire
             ros::spinOnce();
             // Sleep for a microsecond to prevent CPU hogging
-            rate.sleep()
+            rate.sleep();
           }  // While (gps_.IsConnected() && ros::ok()) (inner loop to process data from device)
         }
         else  // Could not connect to the device

--- a/novatel_gps_driver/src/nodelets/novatel_gps_nodelet.cpp
+++ b/novatel_gps_driver/src/nodelets/novatel_gps_nodelet.cpp
@@ -507,6 +507,7 @@ namespace novatel_gps_driver
       {
         gps_.SetSerialBaud(serial_baud_);
       }
+      ros::WallRate rate(1000.0);
       while (ros::ok())
       {
         if (gps_.Connect(device_, connection_, opts))
@@ -546,7 +547,7 @@ namespace novatel_gps_driver
         {
           // If ROS is still OK but we got disconnected, we're going to try
           // to reconnect, but wait just a bit so we don't spam the device.
-          ros::Duration(reconnect_delay_s_).sleep();
+          ros::WallDuration(reconnect_delay_s_).sleep();
         }
 
         // Poke the diagnostic updater. It will only fire diagnostics if
@@ -560,7 +561,7 @@ namespace novatel_gps_driver
         // Spin once to let the ROS callbacks fire
         ros::spinOnce();
         // Sleep for a microsecond to prevent CPU hogging
-        boost::this_thread::sleep(boost::posix_time::microseconds(1));
+        rate.sleep();
 
         if (connection_ == NovatelGps::PCAP)
         {

--- a/novatel_gps_driver/src/nodelets/novatel_gps_nodelet.cpp
+++ b/novatel_gps_driver/src/nodelets/novatel_gps_nodelet.cpp
@@ -530,7 +530,7 @@ namespace novatel_gps_driver
             // Spin once to let the ROS callbacks fire
             ros::spinOnce();
             // Sleep for a microsecond to prevent CPU hogging
-            boost::this_thread::sleep(boost::posix_time::microseconds(1));
+            rate.sleep()
           }  // While (gps_.IsConnected() && ros::ok()) (inner loop to process data from device)
         }
         else  // Could not connect to the device


### PR DESCRIPTION
This fixes #84, where some users were seeing boost sleep forever.