### PR TITLE
Use rclcpp::WallRate to sleep instead of boost (ROS2)

### DIFF
--- a/novatel_gps_driver/src/nodes/novatel_gps_node.cpp
+++ b/novatel_gps_driver/src/nodes/novatel_gps_node.cpp
@@ -378,6 +378,7 @@ namespace novatel_gps_driver
     {
       gps_.SetSerialBaud(serial_baud_);
     }
+    ros::WallRate rate(1000.0);
     while (rclcpp::ok())
     {
       if (gps_.Connect(device_, connection_, opts))
@@ -404,8 +405,7 @@ namespace novatel_gps_driver
             //diagnostic_updater_.force_update();
           }
 
-          // Sleep for a microsecond to prevent CPU hogging
-          boost::this_thread::sleep(boost::posix_time::microseconds(1));
+          rate.sleep();
         }  // While (gps_.IsConnected() && ros::ok()) (inner loop to process data from device)
       }
       else  // Could not connect to the device
@@ -426,8 +426,7 @@ namespace novatel_gps_driver
         rclcpp::sleep_for(std::chrono::milliseconds(static_cast<long>(reconnect_delay_s_ * 1000.0)));
       }
 
-      // Sleep for a microsecond to prevent CPU hogging
-      boost::this_thread::sleep(boost::posix_time::microseconds(1));
+      rate.sleep();
 
       if (connection_ == NovatelGps::PCAP)
       {

--- a/novatel_gps_driver/src/nodes/novatel_gps_node.cpp
+++ b/novatel_gps_driver/src/nodes/novatel_gps_node.cpp
@@ -378,7 +378,7 @@ namespace novatel_gps_driver
     {
       gps_.SetSerialBaud(serial_baud_);
     }
-    ros::WallRate rate(1000.0);
+    rclcpp::WallRate rate(1000.0);
     while (rclcpp::ok())
     {
       if (gps_.Connect(device_, connection_, opts))


### PR DESCRIPTION
Fixes #85.