### PR TITLE
expected_rate based on polling_period parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ Nodelets
             - This will be set as the period for `GPGGA`, `GPRMC`, `GPGSA`, `BESTPOS`, 
             and `BESTVEL` logs.
             - Default: `0.05` (20 Hz)
+        - `expected_rate`: Expected publish rate of GPS messages.
+            - If time between GPS message stamps is greater than 1.5 times the excepted publish rate, diagnostic warning is published.
+            - Default: Based on `polling_period` parameter: `20.0` (20Hz)
         - `publish_clocksteering`: `true` to publish novatel_gps_msgs/ClockSteering messages.
             - Default: `false`
         - `publish_diagnostics`: `true` to publish node diagnostics.

--- a/novatel_gps_driver/src/nodes/novatel_gps_node.cpp
+++ b/novatel_gps_driver/src/nodes/novatel_gps_node.cpp
@@ -114,6 +114,7 @@ namespace novatel_gps_driver
     publish_diagnostics_ = this->declare_parameter("publish_diagnostics", publish_diagnostics_);
     publish_sync_diagnostic_ = this->declare_parameter("publish_sync_diagnostic", publish_sync_diagnostic_);
     polling_period_ = this->declare_parameter("polling_period", polling_period_);
+    expected_rate_ = this->declare_parameter("expected_rate", 1.0 / polling_period_);
     reconnect_delay_s_ = this->declare_parameter("reconnect_delay_s", reconnect_delay_s_);
     use_binary_messages_ = this->declare_parameter("use_binary_messages", use_binary_messages_);
     span_frame_to_ros_frame_ = this->declare_parameter("span_frame_to_ros_frame", span_frame_to_ros_frame_);


### PR DESCRIPTION
According to problems with devices that works on lower rate than 20Hz (e.g https://github.com/swri-robotics/novatel_gps_driver/issues/44#issuecomment-549900322), now default `expected_rate` is based on `polling_period` parameter, moreover there is possibility to set `expected_rate` differently via ROS parameters.