### PR TITLE
Add dual antenna diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ Nodelets
         - `publish_sync_diagnostic`: If true, publish a time Sync diagnostic.
             - Ignored if `publish_diagnostics` is false.
             - Default: `true`
+        - `publish_dual_antenna_diagnostic`: If true, publish diagnostics for the second antenna.
+            - Ignored if `publish_diagnostics` is false.
+            - Default: same as `publish_novatel_dual_antenna_heading`
         - `publish_time_messages`: `true` to publish novatel_gps_msgs/Time messages.
             - Default: `false`
         - `publish_trackstat`: `true` to publish novatel_gps_msgs/Trackstat messages.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Nodelets
         - `publish_clocksteering`: `true` to publish novatel_gps_msgs/ClockSteering messages.
             - Default: `false`
         - `publish_diagnostics`: `true` to publish node diagnostics.
-            - Default: `false`
+            - Default: `true`
         - `publish_gpgsa`: `true` to publish novatel_gps_msgs/Gpgsa messages.
             - Default: `false`
         - `publish_gpgsv`: `true` to publish novatel_gps_msgs/Gpgsv messages.
@@ -173,6 +173,8 @@ Nodelets
         - `publish_time_messages`: `true` to publish novatel_gps_msgs/Time messages.
             - Default: `false`
         - `publish_trackstat`: `true` to publish novatel_gps_msgs/Trackstat messages.
+            - Default: `false`
+        - `publish_invalid_gpsfix`: `true` to publish the `/gps` topic, even if the status of the GPS fix is `STATUS_NO_FIX`.
             - Default: `false`
         - `reconnect_delay_s`: Second delay between reconnection attempts.
             - Default: `0.5`

--- a/novatel_gps_driver/CMakeLists.txt
+++ b/novatel_gps_driver/CMakeLists.txt
@@ -60,6 +60,7 @@ add_library(${PROJECT_NAME}
   src/parsers/range.cpp
   src/parsers/time.cpp
   src/parsers/trackstat.cpp
+  src/parsers/rxstatus.cpp
 )
 set_property(TARGET ${PROJECT_NAME}
   PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/novatel_gps_driver/include/novatel_gps_driver/nodes/novatel_gps_node.h
+++ b/novatel_gps_driver/include/novatel_gps_driver/nodes/novatel_gps_node.h
@@ -220,6 +220,7 @@ namespace novatel_gps_driver
     bool publish_trackstat_;
     bool publish_diagnostics_;
     bool publish_sync_diagnostic_;
+    bool publish_dual_antenna_diagnostic_;
     bool publish_invalid_gpsfix_;
     double reconnect_delay_s_;
     bool use_binary_messages_;
@@ -288,6 +289,11 @@ namespace novatel_gps_driver
     int32_t measurement_count_;
     rclcpp::Time last_published_;
     novatel_gps_msgs::msg::NovatelPosition::SharedPtr last_novatel_position_;
+    // ROS Dual Antenna diagnostics
+    uint32_t aux1stat_;
+    uint32_t aux2stat_;
+    uint32_t aux3stat_;
+    uint32_t aux4stat_;
 
     std::string imu_frame_id_;
     std::string frame_id_;
@@ -326,6 +332,8 @@ namespace novatel_gps_driver
     void DataDiagnostic(diagnostic_updater::DiagnosticStatusWrapper& status);
 
     void RateDiagnostic(diagnostic_updater::DiagnosticStatusWrapper& status);
+
+    void DualAntennaDiagnostic(diagnostic_updater::DiagnosticStatusWrapper& status);
 
     rclcpp::Time NovatelTimeToLocalTime(const TimeParserMsgT & utc_time);
   };

--- a/novatel_gps_driver/include/novatel_gps_driver/novatel_gps.h
+++ b/novatel_gps_driver/include/novatel_gps_driver/novatel_gps.h
@@ -81,6 +81,7 @@
 #include <novatel_gps_driver/parsers/psrdop2.h>
 #include <novatel_gps_driver/parsers/time.h>
 #include <novatel_gps_driver/parsers/trackstat.h>
+#include <novatel_gps_driver/parsers/rxstatus.h>
 
 namespace novatel_gps_driver
 {
@@ -275,6 +276,12 @@ namespace novatel_gps_driver
        * @param[out] clocksteering_msgs New CLOCKSTEERING messages.
        */
       void GetClockSteeringMessages(std::vector<novatel_gps_driver::ClockSteeringParser::MessageType>& clocksteering_msgs);
+      /**
+       * @brief Provides any RXSTATUS messages that have been received since the
+       * last time this was called.
+       * @param[out] rxstatus_msgs New RXSTATUS messages.
+       */
+      void GetRxStatusMessages(std::vector<novatel_gps_driver::RxStatusParser::MessageType>& rxstatus_msgs);
 
       /**
        * @return true if we are connected to a NovAtel device, false otherwise.
@@ -504,6 +511,7 @@ namespace novatel_gps_driver
       RangeParser range_parser_;
       TimeParser time_parser_;
       TrackstatParser trackstat_parser_;
+      RxStatusParser rxstatus_parser_;
 
       // Message buffers
       boost::circular_buffer<novatel_gps_driver::ClockSteeringParser::MessageType> clocksteering_msgs_;
@@ -530,6 +538,7 @@ namespace novatel_gps_driver
       boost::circular_buffer<novatel_gps_driver::RangeParser::MessageType> range_msgs_;
       boost::circular_buffer<novatel_gps_driver::TimeParser::MessageType> time_msgs_;
       boost::circular_buffer<novatel_gps_driver::TrackstatParser::MessageType> trackstat_msgs_;
+      boost::circular_buffer<novatel_gps_driver::RxStatusParser::MessageType> rxstatus_msgs_;
 
       novatel_gps_driver::Psrdop2Parser::MessageType latest_psrdop2_;
 

--- a/novatel_gps_driver/include/novatel_gps_driver/parsers/rxstatus.h
+++ b/novatel_gps_driver/include/novatel_gps_driver/parsers/rxstatus.h
@@ -1,0 +1,58 @@
+// *****************************************************************************
+//
+// Copyright (c) 2019, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL SOUTHWEST RESEARCH INSTITUTE BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+
+#ifndef NOVATEL_GPS_DRIVER_RXSTATUS_H
+#define NOVATEL_GPS_DRIVER_RXSTATUS_H
+
+#include <novatel_gps_msgs/msg/novatel_rx_status.hpp>
+
+#include <novatel_gps_driver/parsers/parsing_utils.h>
+#include <novatel_gps_driver/parsers/message_parser.h>
+
+namespace novatel_gps_driver
+{
+  class RxStatusParser : public MessageParser<novatel_gps_msgs::msg::NovatelRxStatus::SharedPtr>
+  {
+  public:
+    uint32_t GetMessageId() const override;
+
+    const std::string GetMessageName() const override;
+
+    MessageType ParseBinary(const BinaryMessage& bin_msg) noexcept(false) override;
+
+    MessageType ParseAscii(const NovatelSentence& sentence) noexcept(false) override;
+
+    static constexpr uint16_t MESSAGE_ID = 93;
+    static constexpr size_t BINARY_LENGTH = 88;
+    static constexpr size_t ASCII_LENGTH = 22;
+    static const std::string MESSAGE_NAME;
+  };
+}
+
+#endif //NOVATEL_GPS_DRIVER_RXSTATUS_H

--- a/novatel_gps_driver/src/parsers/rxstatus.cpp
+++ b/novatel_gps_driver/src/parsers/rxstatus.cpp
@@ -1,0 +1,102 @@
+// *****************************************************************************
+//
+// Copyright (c) 2019, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL SOUTHWEST RESEARCH INSTITUTE BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+
+#include "novatel_gps_driver/parsers/parsing_utils.h"
+#include <sstream>
+
+#include <novatel_gps_driver/parsers/rxstatus.h>
+
+#include <novatel_gps_driver/parsers/header.h>
+
+namespace novatel_gps_driver
+{
+  const std::string RxStatusParser::MESSAGE_NAME = "RXSTATUS";
+
+  uint32_t RxStatusParser::GetMessageId() const
+  {
+    return MESSAGE_ID;
+  }
+
+  const std::string RxStatusParser::GetMessageName() const
+  {
+    return MESSAGE_NAME;
+  }
+
+  RxStatusParser::MessageType RxStatusParser::ParseBinary(const BinaryMessage& bin_msg) noexcept(false)
+  {
+    if (bin_msg.data_.size() != BINARY_LENGTH)
+    {
+      std::stringstream error;
+      error << "Unexpected RXSTATUS message length: " << bin_msg.data_.size();
+      throw ParseException(error.str());
+    }
+    auto ros_msg = std::make_shared<novatel_gps_msgs::msg::NovatelRxStatus>();
+    HeaderParser header_parser;
+    ros_msg->novatel_msg_header = header_parser.ParseBinary(bin_msg);
+    ros_msg->novatel_msg_header.message_name = MESSAGE_NAME;
+
+    ros_msg->error = ParseUInt32(&bin_msg.data_[0]);
+    ros_msg->rxstat = ParseUInt32(&bin_msg.data_[8]);
+    ros_msg->aux1stat = ParseUInt32(&bin_msg.data_[24]);
+    ros_msg->aux2stat = ParseUInt32(&bin_msg.data_[40]);
+    ros_msg->aux3stat = ParseUInt32(&bin_msg.data_[56]);
+    ros_msg->aux4stat = ParseUInt32(&bin_msg.data_[72]);
+    return ros_msg;
+  }
+
+  RxStatusParser::MessageType RxStatusParser::ParseAscii(const NovatelSentence& sentence) noexcept(false)
+  {
+    auto msg = std::make_shared<novatel_gps_msgs::msg::NovatelRxStatus>();
+    HeaderParser h_parser;
+    msg->novatel_msg_header = h_parser.ParseAscii(sentence);
+
+    if (sentence.body.size() != ASCII_LENGTH)
+    {
+      std::stringstream error;
+      error << "Unexpected number of RXSTATUS message fields: " << sentence.body.size();
+      throw ParseException(error.str());
+    }
+
+    bool valid = true;
+
+    valid = valid && ParseUInt32(sentence.body[0], msg->error);
+    valid = valid && ParseUInt32(sentence.body[1], msg->rxstat);
+    valid = valid && ParseUInt32(sentence.body[6], msg->aux1stat);
+    valid = valid && ParseUInt32(sentence.body[10], msg->aux2stat);
+    valid = valid && ParseUInt32(sentence.body[14], msg->aux3stat);
+    valid = valid && ParseUInt32(sentence.body[18], msg->aux4stat);
+
+    if (!valid)
+    {
+      throw ParseException("Invalid field in RXSTATUS message");
+    }
+
+    return msg;
+  }
+}

--- a/novatel_gps_msgs/CMakeLists.txt
+++ b/novatel_gps_msgs/CMakeLists.txt
@@ -40,6 +40,7 @@ set(MSG_FILES
   msg/Time.msg
   msg/Trackstat.msg
   msg/TrackstatChannel.msg
+  msg/NovatelRxStatus.msg
   srv/NovatelFRESET.srv
 )
 

--- a/novatel_gps_msgs/msg/NovatelRxStatus.msg
+++ b/novatel_gps_msgs/msg/NovatelRxStatus.msg
@@ -1,0 +1,17 @@
+# Based on https://docs.novatel.com/OEM7/Content/Logs/RXSTATUS.htm
+std_msgs/Header header
+
+NovatelMessageHeader novatel_msg_header
+
+# for the bit table of the following values see https://docs.novatel.com/OEM7/Content/Logs/RXSTATUS.htm
+uint32 error
+
+uint32 rxstat
+
+uint32 aux1stat
+
+uint32 aux2stat
+
+uint32 aux3stat
+
+uint32 aux4stat


### PR DESCRIPTION
Added the possibility to publish a dual antenna diagnostic for dual antenna devices (tested on OEM7720).
If the config parameter is set to true, it provides a new diagnostic "Dual Antenna" with the values "Second Antenna Not Powered", "Second Antenna Open" and "Second Antenna Shorted".