### PR TITLE
Added support for `CORRIMUS` and `INSPVAS`, also replaying PCAP in loop.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ def generate_launch_description():
                     'publish_novatel_positions': True,
                     'publish_novatel_velocity': True,
                     'publish_novatel_psrdop2': True,
-                    'frame_id': '/gps'
+                    'frame_id': '/gps',
+                    'loop': True,   
                 }]
             )
         ],
@@ -194,6 +195,8 @@ Nodelets
         messages are received, but a side effect is that the driver will often be unable to fill in the speed & track
         fields.  This has no effect if `publish_novatel_velocity` is `false`.
             - Default: `true`
+        - `loop` : `true` to keep replaying PCAP reply. Only effective when device is `pcap`.
+            - Default: `false`
     2. **ROS Topic Subscriptions**
         - `/gps_sync` *(std_msgs/Time)*: *(optional)* Timestamped sync pulses from a DIO module. 
     These are used to improve the accuracy of the time stamps of the messages published.

--- a/novatel_gps_driver/CMakeLists.txt
+++ b/novatel_gps_driver/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(${PROJECT_NAME}
   src/parsers/bestxyz.cpp
   src/parsers/clocksteering.cpp
   src/parsers/corrimudata.cpp
+  src/parsers/corrimus.cpp
   src/parsers/dual_antenna_heading.cpp
   src/parsers/gpgga.cpp
   src/parsers/gpgsa.cpp
@@ -53,6 +54,7 @@ add_library(${PROJECT_NAME}
   src/parsers/heading2.cpp
   src/parsers/inscov.cpp
   src/parsers/inspva.cpp
+  src/parsers/inspvas.cpp
   src/parsers/inspvax.cpp
   src/parsers/insstdev.cpp
   src/parsers/parsing_utils.cpp

--- a/novatel_gps_driver/include/novatel_gps_driver/binary_header.h
+++ b/novatel_gps_driver/include/novatel_gps_driver/binary_header.h
@@ -95,6 +95,18 @@ namespace novatel_gps_driver
       receiver_status_ = ParseUInt32(&data[20]);
       receiver_sw_version_ = ParseUInt16(&data[26]);
     }
+
+    void ParseShortHeader(const uint8_t* data)
+    {
+      sync0_ = data[0];
+      sync1_ = data[1];
+      sync2_ = data[2];
+      message_length_ = data[3];
+      message_id_ = ParseUInt16(&data[4]);
+      week_ = ParseUInt16(&data[6]);
+      gps_ms_ = ParseUInt32(&data[8]);
+      header_length_ = 12;  // TODO: HardCoding for now
+    }
   };
 }
 #endif //NOVATEL_GPS_DRIVER_BINARY_HEADER_H

--- a/novatel_gps_driver/include/novatel_gps_driver/nodes/novatel_gps_node.h
+++ b/novatel_gps_driver/include/novatel_gps_driver/nodes/novatel_gps_node.h
@@ -297,6 +297,7 @@ namespace novatel_gps_driver
 
     std::string imu_frame_id_;
     std::string frame_id_;
+    bool on_loop_;
 
     /**
      * @brief Service request to reset the gps through FRESET

--- a/novatel_gps_driver/include/novatel_gps_driver/novatel_gps.h
+++ b/novatel_gps_driver/include/novatel_gps_driver/novatel_gps.h
@@ -66,6 +66,7 @@
 #include <novatel_gps_driver/parsers/bestvel.h>
 #include <novatel_gps_driver/parsers/clocksteering.h>
 #include <novatel_gps_driver/parsers/corrimudata.h>
+#include <novatel_gps_driver/parsers/corrimus.h>
 #include <novatel_gps_driver/parsers/gpgga.h>
 #include <novatel_gps_driver/parsers/gpgsa.h>
 #include <novatel_gps_driver/parsers/gpgsv.h>
@@ -75,6 +76,7 @@
 #include <novatel_gps_driver/parsers/dual_antenna_heading.h>
 #include <novatel_gps_driver/parsers/inscov.h>
 #include <novatel_gps_driver/parsers/inspva.h>
+#include <novatel_gps_driver/parsers/inspvas.h>
 #include <novatel_gps_driver/parsers/inspvax.h>
 #include <novatel_gps_driver/parsers/insstdev.h>
 #include <novatel_gps_driver/parsers/range.h>
@@ -211,6 +213,11 @@ namespace novatel_gps_driver
        */
       void GetInspvaMessages(std::vector<novatel_gps_driver::InspvaParser::MessageType>& inspva_messages);
       /**
+       * @brief Provides any INSPVAS messages that have been received since the last
+       * time this was called.
+       * @param[out] inspvas_messages New INSPVAS messages.
+       */
+      void GetInspvasMessages(std::vector<novatel_gps_driver::InspvasParser::MessageType>& inspvas_messages);      /**
        * @brief Provides any INSPVAX messages that have been received since the last
        * time this was called.
        * @param[out] inspvax_messages New INSPVAX messages.
@@ -228,6 +235,12 @@ namespace novatel_gps_driver
        * @param[out] imu_messages New CORRIMUDATA messages.
        */
       void GetNovatelCorrectedImuData(std::vector<novatel_gps_driver::CorrImuDataParser::MessageType>& imu_messages);
+      /**
+       * @brief Provides any CORRIMUS messages that have been received since the
+       * last time this was called.
+       * @param[out] imu_messages New CORRIMUS messages.
+       */
+      void GetNovatelCorrectedImus(std::vector<novatel_gps_driver::CorrImusParser::MessageType>& imu_messages);
       /**
        * @brief Provides any BESTPOS messages that have been received since the
        * last time this was called.
@@ -498,6 +511,7 @@ namespace novatel_gps_driver
       DualAntennaHeadingParser dual_antenna_heading_parser_;
       ClockSteeringParser clocksteering_parser_;
       CorrImuDataParser corrimudata_parser_;
+      CorrImusParser corrimus_parser_;
       GpggaParser gpgga_parser_;
       GpgsaParser gpgsa_parser_;
       GpgsvParser gpgsv_parser_;
@@ -505,6 +519,7 @@ namespace novatel_gps_driver
       GprmcParser gprmc_parser_;
       InscovParser inscov_parser_;
       InspvaParser inspva_parser_;
+      InspvasParser inspvas_parser_;
       InspvaxParser inspvax_parser_;
       InsstdevParser insstdev_parser_;
       Psrdop2Parser psrdop2_parser_;
@@ -516,6 +531,7 @@ namespace novatel_gps_driver
       // Message buffers
       boost::circular_buffer<novatel_gps_driver::ClockSteeringParser::MessageType> clocksteering_msgs_;
       boost::circular_buffer<novatel_gps_driver::CorrImuDataParser::MessageType> corrimudata_msgs_;
+      boost::circular_buffer<novatel_gps_driver::CorrImusParser::MessageType> corrimus_msgs_;
       boost::circular_buffer<novatel_gps_driver::GpggaParser::MessageType> gpgga_msgs_;
       boost::circular_buffer<novatel_gps_driver::GpgsaParser::MessageType> gpgsa_msgs_;
       boost::circular_buffer<novatel_gps_driver::GpgsvParser::MessageType> gpgsv_msgs_;
@@ -524,6 +540,7 @@ namespace novatel_gps_driver
       boost::circular_buffer<sensor_msgs::msg::Imu::SharedPtr> imu_msgs_;
       boost::circular_buffer<novatel_gps_driver::InscovParser::MessageType> inscov_msgs_;
       boost::circular_buffer<novatel_gps_driver::InspvaParser::MessageType> inspva_msgs_;
+      boost::circular_buffer<novatel_gps_driver::InspvasParser::MessageType> inspvas_msgs_;
       boost::circular_buffer<novatel_gps_driver::InspvaxParser::MessageType> inspvax_msgs_;
       boost::circular_buffer<novatel_gps_driver::InsstdevParser::MessageType> insstdev_msgs_;
       boost::circular_buffer<novatel_gps_driver::BestposParser::MessageType> novatel_positions_;
@@ -544,7 +561,9 @@ namespace novatel_gps_driver
 
       // IMU data synchronization queues
       std::queue<novatel_gps_driver::CorrImuDataParser::MessageType> corrimudata_queue_;
+      std::queue<novatel_gps_driver::CorrImusParser::MessageType> corrimus_queue_;
       std::queue<novatel_gps_driver::InspvaParser::MessageType> inspva_queue_;
+      std::queue<novatel_gps_driver::InspvasParser::MessageType> inspvas_queue_;
       novatel_gps_driver::InsstdevParser::MessageType latest_insstdev_;
       novatel_gps_driver::InscovParser::MessageType latest_inscov_;
       double imu_rate_;

--- a/novatel_gps_driver/include/novatel_gps_driver/novatel_gps.h
+++ b/novatel_gps_driver/include/novatel_gps_driver/novatel_gps.h
@@ -217,7 +217,8 @@ namespace novatel_gps_driver
        * time this was called.
        * @param[out] inspvas_messages New INSPVAS messages.
        */
-      void GetInspvasMessages(std::vector<novatel_gps_driver::InspvasParser::MessageType>& inspvas_messages);      /**
+      void GetInspvasMessages(std::vector<novatel_gps_driver::InspvasParser::MessageType>& inspvas_messages);      
+      /**
        * @brief Provides any INSPVAX messages that have been received since the last
        * time this was called.
        * @param[out] inspvax_messages New INSPVAX messages.

--- a/novatel_gps_driver/include/novatel_gps_driver/novatel_message_extractor.h
+++ b/novatel_gps_driver/include/novatel_gps_driver/novatel_message_extractor.h
@@ -124,6 +124,7 @@ namespace novatel_gps_driver
     static const std::string NOVATEL_ASCII_FLAGS;
     /// Indicates the beginning of a binary NovAtel message
     static const std::string NOVATEL_BINARY_SYNC_BYTES;
+    static const std::string NOVATEL_BINARY_SYNC_BYTES2;
     /// Indicates the end of an ASCII message
     static const std::string NOVATEL_ENDLINE;
 

--- a/novatel_gps_driver/include/novatel_gps_driver/parsers/corrimus.h
+++ b/novatel_gps_driver/include/novatel_gps_driver/parsers/corrimus.h
@@ -27,24 +27,15 @@
 //
 // *****************************************************************************
 
-#ifndef NOVATEL_GPS_DRIVER_HEADER_H
-#define NOVATEL_GPS_DRIVER_HEADER_H
+#ifndef NOVATEL_GPS_DRIVER_CORRIMUS_H
+#define NOVATEL_GPS_DRIVER_CORRIMUS_H
 
-#include <novatel_gps_driver/parsers/parsing_utils.h>
 #include <novatel_gps_driver/parsers/message_parser.h>
-
-#include <novatel_gps_msgs/msg/novatel_message_header.hpp>
+#include <novatel_gps_msgs/msg/novatel_corrected_imu_data.hpp>
 
 namespace novatel_gps_driver
 {
-  /**
-   * Parses the header in a typical NovAtel message.
-   *
-   * Note that this parser is actually a little different from the others; it is used by the other
-   * parsers to parse headers in their messages, and it does not return a Ptr type because the headers
-   * in the ROS message classes are assigned by value.
-   */
-  class HeaderParser : public MessageParser<novatel_gps_msgs::msg::NovatelMessageHeader>
+  class CorrImusParser : public MessageParser<novatel_gps_msgs::msg::NovatelCorrectedImuData::SharedPtr>
   {
   public:
     uint32_t GetMessageId() const override;
@@ -52,13 +43,14 @@ namespace novatel_gps_driver
     const std::string GetMessageName() const override;
 
     MessageType ParseBinary(const BinaryMessage& bin_msg) noexcept(false) override;
-    MessageType ParseShortBinary(const BinaryMessage& bin_msg) noexcept(false);
 
-    MessageType ParseAscii(const NovatelSentence& sentence) noexcept(false) override;
+    // MessageType ParseAscii(const NovatelSentence& sentence) noexcept(false) override;
 
-    static constexpr uint32_t BINARY_HEADER_LENGTH = 28;
-    static constexpr uint32_t BINARY_SHORT_HEADER_LENGTH = 12;
+    static constexpr uint16_t MESSAGE_ID = 2264;
+    static constexpr size_t BINARY_LENGTH = 60;
+    static constexpr size_t ASCII_FIELDS = 7;
+    static const std::string MESSAGE_NAME;
   };
 }
 
-#endif //NOVATEL_GPS_DRIVER_HEADER_H
+#endif //NOVATEL_GPS_DRIVER_CORRIMUS_H

--- a/novatel_gps_driver/include/novatel_gps_driver/parsers/inspvas.h
+++ b/novatel_gps_driver/include/novatel_gps_driver/parsers/inspvas.h
@@ -27,24 +27,15 @@
 //
 // *****************************************************************************
 
-#ifndef NOVATEL_GPS_DRIVER_HEADER_H
-#define NOVATEL_GPS_DRIVER_HEADER_H
+#ifndef NOVATEL_GPS_DRIVER_INSPVAS_H
+#define NOVATEL_GPS_DRIVER_INSPVAS_H
 
-#include <novatel_gps_driver/parsers/parsing_utils.h>
 #include <novatel_gps_driver/parsers/message_parser.h>
-
-#include <novatel_gps_msgs/msg/novatel_message_header.hpp>
+#include <novatel_gps_msgs/msg/inspva.hpp>
 
 namespace novatel_gps_driver
 {
-  /**
-   * Parses the header in a typical NovAtel message.
-   *
-   * Note that this parser is actually a little different from the others; it is used by the other
-   * parsers to parse headers in their messages, and it does not return a Ptr type because the headers
-   * in the ROS message classes are assigned by value.
-   */
-  class HeaderParser : public MessageParser<novatel_gps_msgs::msg::NovatelMessageHeader>
+  class InspvasParser : public MessageParser<novatel_gps_msgs::msg::Inspva::SharedPtr>
   {
   public:
     uint32_t GetMessageId() const override;
@@ -52,13 +43,14 @@ namespace novatel_gps_driver
     const std::string GetMessageName() const override;
 
     MessageType ParseBinary(const BinaryMessage& bin_msg) noexcept(false) override;
-    MessageType ParseShortBinary(const BinaryMessage& bin_msg) noexcept(false);
 
-    MessageType ParseAscii(const NovatelSentence& sentence) noexcept(false) override;
+    // MessageType ParseAscii(const NovatelSentence& sentence) noexcept(false) override;
 
-    static constexpr uint32_t BINARY_HEADER_LENGTH = 28;
-    static constexpr uint32_t BINARY_SHORT_HEADER_LENGTH = 12;
+    static constexpr uint32_t MESSAGE_ID = 508;
+    static const std::string MESSAGE_NAME;
+    static constexpr size_t BINARY_LENGTH = 88;
+    static constexpr size_t ASCII_FIELDS = 12;
   };
 }
 
-#endif //NOVATEL_GPS_DRIVER_HEADER_H
+#endif //NOVATEL_GPS_DRIVER_INSPVAS_H

--- a/novatel_gps_driver/include/novatel_gps_driver/parsers/inspvas.h
+++ b/novatel_gps_driver/include/novatel_gps_driver/parsers/inspvas.h
@@ -44,8 +44,6 @@ namespace novatel_gps_driver
 
     MessageType ParseBinary(const BinaryMessage& bin_msg) noexcept(false) override;
 
-    // MessageType ParseAscii(const NovatelSentence& sentence) noexcept(false) override;
-
     static constexpr uint32_t MESSAGE_ID = 508;
     static const std::string MESSAGE_NAME;
     static constexpr size_t BINARY_LENGTH = 88;

--- a/novatel_gps_driver/src/parsers/corrimus.cpp
+++ b/novatel_gps_driver/src/parsers/corrimus.cpp
@@ -68,34 +68,3 @@ novatel_gps_driver::CorrImusParser::ParseBinary(const novatel_gps_driver::Binary
 
   return ros_msg;
 }
-
-// novatel_gps_driver::CorrImusParser::MessageType
-// novatel_gps_driver::CorrImusParser::ParseAscii(const novatel_gps_driver::NovatelSentence& sentence) noexcept(false)
-// {
-//   if (sentence.body.size() != ASCII_FIELDS)
-//   {
-//     std::stringstream error;
-//     error << "Unexpected number of fields in CORRIMUDATA log: " << sentence.body.size();
-//     throw ParseException(error.str());
-//   }
-//   auto msg = std::make_shared<novatel_gps_msgs::msg::NovatelCorrectedImuData>();
-//   HeaderParser h_parser;
-//   msg->novatel_msg_header = h_parser.ParseAscii(sentence);
-//   msg->novatel_msg_header.message_name = "CORRIMUS";
-//   bool valid = true;
-
-//   valid &= ParseUInt32(sentence.body[0], msg->imu_data_count);
-//   valid &= ParseDouble(sentence.body[1], msg->pitch_rate);
-//   valid &= ParseDouble(sentence.body[2], msg->roll_rate);
-//   valid &= ParseDouble(sentence.body[3], msg->yaw_rate);
-//   valid &= ParseDouble(sentence.body[4], msg->lateral_acceleration);
-//   valid &= ParseDouble(sentence.body[5], msg->longitudinal_acceleration);
-//   valid &= ParseDouble(sentence.body[6], msg->vertical_acceleration);
-
-//   if (!valid)
-//   {
-//     throw ParseException("Error parsing CORRIMUDATA log.");
-//   }
-
-//   return msg;
-// }

--- a/novatel_gps_driver/src/parsers/corrimus.cpp
+++ b/novatel_gps_driver/src/parsers/corrimus.cpp
@@ -1,0 +1,101 @@
+// *****************************************************************************
+//
+// Copyright (c) 2019, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL SOUTHWEST RESEARCH INSTITUTE BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+
+#include <sstream>
+
+#include <novatel_gps_driver/parsers/corrimus.h>
+#include <novatel_gps_driver/parsers/header.h>
+
+const std::string novatel_gps_driver::CorrImusParser::MESSAGE_NAME = "CORRIMUS";
+
+uint32_t novatel_gps_driver::CorrImusParser::GetMessageId() const
+{
+  return MESSAGE_ID;
+}
+
+const std::string novatel_gps_driver::CorrImusParser::GetMessageName() const
+{
+  return MESSAGE_NAME;
+}
+
+novatel_gps_driver::CorrImusParser::MessageType
+novatel_gps_driver::CorrImusParser::ParseBinary(const novatel_gps_driver::BinaryMessage& bin_msg) noexcept(false)
+{
+  if (bin_msg.data_.size() != BINARY_LENGTH)
+  {
+    std::stringstream error;
+    error << "Unexpected corrimus message size: " << bin_msg.data_.size();
+    throw ParseException(error.str());
+  }
+  auto ros_msg = std::make_shared<novatel_gps_msgs::msg::NovatelCorrectedImuData>();
+  HeaderParser h_parser;
+  ros_msg->novatel_msg_header = h_parser.ParseShortBinary(bin_msg);
+  ros_msg->novatel_msg_header.message_name = GetMessageName();
+
+  ros_msg->imu_data_count = ParseUInt32(&bin_msg.data_[0]);
+  ros_msg->pitch_rate = ParseDouble(&bin_msg.data_[4]);
+  ros_msg->roll_rate = ParseDouble(&bin_msg.data_[12]);
+  ros_msg->yaw_rate = ParseDouble(&bin_msg.data_[20]);
+  ros_msg->lateral_acceleration = ParseDouble(&bin_msg.data_[28]);
+  ros_msg->longitudinal_acceleration = ParseDouble(&bin_msg.data_[36]);
+  ros_msg->vertical_acceleration = ParseDouble(&bin_msg.data_[44]);
+
+  return ros_msg;
+}
+
+// novatel_gps_driver::CorrImusParser::MessageType
+// novatel_gps_driver::CorrImusParser::ParseAscii(const novatel_gps_driver::NovatelSentence& sentence) noexcept(false)
+// {
+//   if (sentence.body.size() != ASCII_FIELDS)
+//   {
+//     std::stringstream error;
+//     error << "Unexpected number of fields in CORRIMUDATA log: " << sentence.body.size();
+//     throw ParseException(error.str());
+//   }
+//   auto msg = std::make_shared<novatel_gps_msgs::msg::NovatelCorrectedImuData>();
+//   HeaderParser h_parser;
+//   msg->novatel_msg_header = h_parser.ParseAscii(sentence);
+//   msg->novatel_msg_header.message_name = "CORRIMUS";
+//   bool valid = true;
+
+//   valid &= ParseUInt32(sentence.body[0], msg->imu_data_count);
+//   valid &= ParseDouble(sentence.body[1], msg->pitch_rate);
+//   valid &= ParseDouble(sentence.body[2], msg->roll_rate);
+//   valid &= ParseDouble(sentence.body[3], msg->yaw_rate);
+//   valid &= ParseDouble(sentence.body[4], msg->lateral_acceleration);
+//   valid &= ParseDouble(sentence.body[5], msg->longitudinal_acceleration);
+//   valid &= ParseDouble(sentence.body[6], msg->vertical_acceleration);
+
+//   if (!valid)
+//   {
+//     throw ParseException("Error parsing CORRIMUDATA log.");
+//   }
+
+//   return msg;
+// }

--- a/novatel_gps_driver/src/parsers/header.cpp
+++ b/novatel_gps_driver/src/parsers/header.cpp
@@ -103,7 +103,7 @@ novatel_gps_driver::HeaderParser::MessageType novatel_gps_driver::HeaderParser::
 novatel_gps_driver::HeaderParser::MessageType novatel_gps_driver::HeaderParser::ParseShortBinary(
   const novatel_gps_driver::BinaryMessage& bin_msg) noexcept(false)
 {
-// Only keeping valida data we're getting from Short header
+// Only keeping valid data we're getting from Short header
 novatel_gps_msgs::msg::NovatelMessageHeader msg;
 msg.gps_time_status = "UNKNOWN";       // GPS Ref time unknown.
 msg.gps_week_num = bin_msg.header_.week_;

--- a/novatel_gps_driver/src/parsers/header.cpp
+++ b/novatel_gps_driver/src/parsers/header.cpp
@@ -100,6 +100,17 @@ novatel_gps_driver::HeaderParser::MessageType novatel_gps_driver::HeaderParser::
   return msg;
 }
 
+novatel_gps_driver::HeaderParser::MessageType novatel_gps_driver::HeaderParser::ParseShortBinary(
+  const novatel_gps_driver::BinaryMessage& bin_msg) noexcept(false)
+{
+// Only keeping valida data we're getting from Short header
+novatel_gps_msgs::msg::NovatelMessageHeader msg;
+msg.gps_time_status = "UNKNOWN";       // GPS Ref time unknown.
+msg.gps_week_num = bin_msg.header_.week_;
+msg.gps_seconds = static_cast<double>(bin_msg.header_.gps_ms_) / 1000.0;
+return msg;
+}
+
 novatel_gps_driver::HeaderParser::MessageType novatel_gps_driver::HeaderParser::ParseAscii(
     const novatel_gps_driver::NovatelSentence& sentence) noexcept(false)
 {

--- a/novatel_gps_driver/src/parsers/inspvas.cpp
+++ b/novatel_gps_driver/src/parsers/inspvas.cpp
@@ -1,0 +1,154 @@
+// *****************************************************************************
+//
+// Copyright (c) 2019, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL SOUTHWEST RESEARCH INSTITUTE BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+
+#include <sstream>
+
+#include <novatel_gps_driver/parsers/inspvas.h>
+#include <novatel_gps_driver/parsers/header.h>
+
+const std::string novatel_gps_driver::InspvasParser::MESSAGE_NAME = "INSPVAS";
+
+uint32_t novatel_gps_driver::InspvasParser::GetMessageId() const
+{
+  return MESSAGE_ID;
+}
+
+const std::string novatel_gps_driver::InspvasParser::GetMessageName() const
+{
+  return MESSAGE_NAME;
+}
+
+novatel_gps_driver::InspvasParser::MessageType
+novatel_gps_driver::InspvasParser::ParseBinary(const novatel_gps_driver::BinaryMessage& bin_msg) noexcept(false)
+{
+  if (bin_msg.data_.size() != BINARY_LENGTH)
+  {
+    std::stringstream error;
+    error << "Unexpected inspva message size: " << bin_msg.data_.size();
+    throw ParseException(error.str());
+  }
+  auto ros_msg = std::make_shared<novatel_gps_msgs::msg::Inspva>();
+  HeaderParser h_parser;
+  ros_msg->novatel_msg_header = h_parser.ParseShortBinary(bin_msg);
+  ros_msg->novatel_msg_header.message_name = GetMessageName();
+
+  ros_msg->week = ParseUInt32(&bin_msg.data_[0]);
+  ros_msg->seconds = ParseDouble(&bin_msg.data_[4]);
+  ros_msg->latitude = ParseDouble(&bin_msg.data_[12]);
+  ros_msg->longitude = ParseDouble(&bin_msg.data_[20]);
+  ros_msg->height = ParseDouble(&bin_msg.data_[28]);
+  ros_msg->north_velocity = ParseDouble(&bin_msg.data_[36]);
+  ros_msg->east_velocity = ParseDouble(&bin_msg.data_[44]);
+  ros_msg->up_velocity = ParseDouble(&bin_msg.data_[52]);
+  ros_msg->roll = ParseDouble(&bin_msg.data_[60]);
+  ros_msg->pitch = ParseDouble(&bin_msg.data_[68]);
+  ros_msg->azimuth = ParseDouble(&bin_msg.data_[76]);
+  uint32_t status = ParseUInt32(&bin_msg.data_[84]);
+
+  switch (status)
+  {
+    case 0:
+      ros_msg->status = "INS_INACTIVE";
+      break;
+    case 1:
+      ros_msg->status = "INS_ALIGNING";
+      break;
+    case 2:
+      ros_msg->status = "INS_HIGH_VARIANCE";
+      break;
+    case 3:
+      ros_msg->status = "INS_SOLUTION_GOOD";
+      break;
+    case 6:
+      ros_msg->status = "INS_SOLUTION_FREE";
+      break;
+    case 7:
+      ros_msg->status = "INS_ALIGNMENT_COMPLETE";
+      break;
+    case 8:
+      ros_msg->status = "DETERMINING_ORIENTATION";
+      break;
+    case 9:
+      ros_msg->status = "WAITING_INITIALPOS";
+      break;
+    case 10:
+      ros_msg->status = "WAITING_AZIMUTH";
+      break;
+    case 11:
+      ros_msg->status = "INITIALIZING_BASES";
+      break;
+    case 12:
+      ros_msg->status = "MOTION_DETECT";
+      break;
+    default:
+    {
+      std::stringstream error;
+      error << "Unexpected inertial solution status: " << status;
+      throw ParseException(error.str());
+    }
+  }
+
+  return ros_msg;
+}
+
+// novatel_gps_driver::InspvasParser::MessageType
+// novatel_gps_driver::InspvasParser::ParseAscii(const novatel_gps_driver::NovatelSentence& sentence) noexcept(false)
+// {
+//   if (sentence.body.size() != ASCII_FIELDS)
+//   {
+//     std::stringstream error;
+//     error << "Unexpected number of fields in INSPVA log: " << sentence.body.size();
+//     throw ParseException(error.str());
+//   }
+//   auto msg = std::make_shared<novatel_gps_msgs::msg::Inspva>();
+//   HeaderParser h_parser;
+//   msg->novatel_msg_header = h_parser.ParseAscii(sentence);
+
+//   bool valid = true;
+
+//   valid &= ParseUInt32(sentence.body[0], msg->week);
+//   valid &= ParseDouble(sentence.body[1], msg->seconds);
+//   valid &= ParseDouble(sentence.body[2], msg->latitude);
+//   valid &= ParseDouble(sentence.body[3], msg->longitude);
+//   valid &= ParseDouble(sentence.body[4], msg->height);
+//   valid &= ParseDouble(sentence.body[5], msg->north_velocity);
+//   valid &= ParseDouble(sentence.body[6], msg->east_velocity);
+//   valid &= ParseDouble(sentence.body[7], msg->up_velocity);
+//   valid &= ParseDouble(sentence.body[8], msg->roll);
+//   valid &= ParseDouble(sentence.body[9], msg->pitch);
+//   valid &= ParseDouble(sentence.body[10], msg->azimuth);
+//   msg->status = sentence.body[11];
+
+//   if (!valid)
+//   {
+//     throw ParseException("Error parsing INSPVA log.");
+//   }
+
+//   return msg;
+// }

--- a/novatel_gps_driver/src/parsers/inspvas.cpp
+++ b/novatel_gps_driver/src/parsers/inspvas.cpp
@@ -116,39 +116,3 @@ novatel_gps_driver::InspvasParser::ParseBinary(const novatel_gps_driver::BinaryM
 
   return ros_msg;
 }
-
-// novatel_gps_driver::InspvasParser::MessageType
-// novatel_gps_driver::InspvasParser::ParseAscii(const novatel_gps_driver::NovatelSentence& sentence) noexcept(false)
-// {
-//   if (sentence.body.size() != ASCII_FIELDS)
-//   {
-//     std::stringstream error;
-//     error << "Unexpected number of fields in INSPVA log: " << sentence.body.size();
-//     throw ParseException(error.str());
-//   }
-//   auto msg = std::make_shared<novatel_gps_msgs::msg::Inspva>();
-//   HeaderParser h_parser;
-//   msg->novatel_msg_header = h_parser.ParseAscii(sentence);
-
-//   bool valid = true;
-
-//   valid &= ParseUInt32(sentence.body[0], msg->week);
-//   valid &= ParseDouble(sentence.body[1], msg->seconds);
-//   valid &= ParseDouble(sentence.body[2], msg->latitude);
-//   valid &= ParseDouble(sentence.body[3], msg->longitude);
-//   valid &= ParseDouble(sentence.body[4], msg->height);
-//   valid &= ParseDouble(sentence.body[5], msg->north_velocity);
-//   valid &= ParseDouble(sentence.body[6], msg->east_velocity);
-//   valid &= ParseDouble(sentence.body[7], msg->up_velocity);
-//   valid &= ParseDouble(sentence.body[8], msg->roll);
-//   valid &= ParseDouble(sentence.body[9], msg->pitch);
-//   valid &= ParseDouble(sentence.body[10], msg->azimuth);
-//   msg->status = sentence.body[11];
-
-//   if (!valid)
-//   {
-//     throw ParseException("Error parsing INSPVA log.");
-//   }
-
-//   return msg;
-// }

--- a/novatel_gps_msgs/msg/NovatelCorrectedImuData.msg
+++ b/novatel_gps_msgs/msg/NovatelCorrectedImuData.msg
@@ -3,6 +3,8 @@ std_msgs/Header header
 
 NovatelMessageHeader novatel_msg_header
 
+# Count of the number of IMU Samples used in each log output accumulation.
+# 0 if unknown.
 uint32 imu_data_count
 uint32 gps_week_num
 float64 gps_seconds

--- a/novatel_gps_msgs/msg/NovatelCorrectedImuData.msg
+++ b/novatel_gps_msgs/msg/NovatelCorrectedImuData.msg
@@ -3,6 +3,7 @@ std_msgs/Header header
 
 NovatelMessageHeader novatel_msg_header
 
+uint32 imu_data_count
 uint32 gps_week_num
 float64 gps_seconds
 


### PR DESCRIPTION
In latest edition of Novatel logs, short header has been introduced for high frequnecy logs. With Sync bytes `AA4413` . Added short header and respective message decoding for binary reading only. ASCII update pending. 

Also, added `loop` arg for keep playing PCAP player.