### PR TITLE
Fix INS status decoding in binary INSPVAX logs

### DIFF
--- a/novatel_gps_driver/src/parsers/inspvax.cpp
+++ b/novatel_gps_driver/src/parsers/inspvax.cpp
@@ -27,6 +27,7 @@
 //
 // *****************************************************************************
 
+#include <array>
 #include <sstream>
 
 #include <novatel_gps_driver/parsers/inspvax.h>
@@ -59,14 +60,22 @@ novatel_gps_driver::InspvaxParser::ParseBinary(const novatel_gps_driver::BinaryM
   ros_msg->novatel_msg_header = h_parser.ParseBinary(bin_msg);
   ros_msg->novatel_msg_header.message_name = GetMessageName();
 
-  uint16_t solution_status = ParseUInt16(&bin_msg.data_[0]);
-  if (solution_status > MAX_SOLUTION_STATUS)
+  // INSPVAX uses the inertial solution status codes, not the BESTPOS codes.
+  static const std::array<const char*, 15> INS_SOLUTION_STATUSES = {{
+    "INS_INACTIVE", "INS_ALIGNING", "INS_HIGH_VARIANCE", "INS_SOLUTION_GOOD",
+    nullptr, nullptr, "INS_SOLUTION_FREE", "INS_ALIGNMENT_COMPLETE",
+    "DETERMINING_ORIENTATION", "WAITING_INITIALPOS", "WAITING_AZIMUTH",
+    "INITIALIZING_BIASES", "MOTION_DETECT", nullptr, "WAITING_ALIGNMENTORIENTATION"
+  }};
+  uint32_t solution_status = ParseUInt32(&bin_msg.data_[0]);
+  if (solution_status >= INS_SOLUTION_STATUSES.size() ||
+      INS_SOLUTION_STATUSES[solution_status] == nullptr)
   {
     std::stringstream error;
-    error << "Unknown solution status: " << solution_status;
+    error << "Unknown inertial solution status: " << solution_status;
     throw ParseException(error.str());
   }
-  ros_msg->ins_status = SOLUTION_STATUSES[solution_status];
+  ros_msg->ins_status = INS_SOLUTION_STATUSES[solution_status];
   uint16_t pos_type = ParseUInt16(&bin_msg.data_[4]);
   if (pos_type > MAX_POSITION_TYPE)
   {
@@ -161,4 +170,3 @@ novatel_gps_driver::InspvaxParser::ParseAscii(const novatel_gps_driver::NovatelS
 
   return msg;
 }
-

--- a/novatel_gps_driver/test/parser_tests.cpp
+++ b/novatel_gps_driver/test/parser_tests.cpp
@@ -37,7 +37,9 @@
 #include <novatel_gps_driver/parsers/dual_antenna_heading.h>
 
 #include <gtest/gtest.h>
+#include <utility>
 #include <novatel_gps_driver/parsers/inspva.h>
+#include <novatel_gps_driver/parsers/inspvax.h>
 #include <novatel_gps_driver/parsers/insstdev.h>
 #include <novatel_gps_driver/parsers/corrimudata.h>
 #include <novatel_gps_driver/parsers/inscov.h>
@@ -45,6 +47,53 @@
 #include <rclcpp/rclcpp.hpp>
 
 rclcpp::Logger logger = rclcpp::get_logger("parser_tests");
+
+TEST(ParserTestSuite, testInspvaxBinarySolutionStatus)
+{
+  novatel_gps_driver::InspvaxParser parser;
+  novatel_gps_driver::BinaryMessage message;
+  message.header_.time_status_ = 20;
+  message.data_.resize(novatel_gps_driver::InspvaxParser::BINARY_LENGTH, 0);
+
+  const std::vector<std::pair<uint8_t, std::string>> statuses = {
+    {0, "INS_INACTIVE"},
+    {1, "INS_ALIGNING"},
+    {2, "INS_HIGH_VARIANCE"},
+    {3, "INS_SOLUTION_GOOD"},
+    {6, "INS_SOLUTION_FREE"},
+    {7, "INS_ALIGNMENT_COMPLETE"},
+    {8, "DETERMINING_ORIENTATION"},
+    {9, "WAITING_INITIALPOS"},
+    {10, "WAITING_AZIMUTH"},
+    {11, "INITIALIZING_BIASES"},
+    {12, "MOTION_DETECT"},
+    {14, "WAITING_ALIGNMENTORIENTATION"}
+  };
+  for (const auto& status : statuses)
+  {
+    SCOPED_TRACE(static_cast<unsigned int>(status.first));
+    message.data_[0] = status.first;
+    EXPECT_EQ(status.second, parser.ParseBinary(message)->ins_status);
+  }
+}
+
+TEST(ParserTestSuite, testInspvaxBinaryInvalidSolutionStatus)
+{
+  novatel_gps_driver::InspvaxParser parser;
+  novatel_gps_driver::BinaryMessage message;
+  message.header_.time_status_ = 20;
+  message.data_.resize(novatel_gps_driver::InspvaxParser::BINARY_LENGTH, 0);
+
+  for (uint32_t status : {4u, 5u, 13u, 15u, 65539u})
+  {
+    SCOPED_TRACE(status);
+    for (size_t byte = 0; byte < sizeof(status); ++byte)
+    {
+      message.data_[byte] = static_cast<uint8_t>(status >> (8 * byte));
+    }
+    EXPECT_THROW(parser.ParseBinary(message), novatel_gps_driver::ParseException);
+  }
+}
 
 TEST(ParserTestSuite, testBestposAsciiParsing)
 {


### PR DESCRIPTION
Fixes #83 for binary INSPVAX logs. The parser uses the BESTPOS status table, so code 3 is reported as `SINGULARITY` instead of `INS_SOLUTION_GOOD`.

Use the [INS status table](https://docs.novatel.com/OEM7/Content/SPAN_Logs/INSATT.htm#InertialSolutionStatus) and read the full 32-bit field. Adds tests for the documented statuses and invalid values. The driver build and tests pass on Rolling, including the existing PCAP tests.
